### PR TITLE
Add AuthToken support and refactor MovieService

### DIFF
--- a/Movies.VerticalSlice.Api.Services/Services/IMovieService.cs
+++ b/Movies.VerticalSlice.Api.Services/Services/IMovieService.cs
@@ -4,6 +4,8 @@ namespace Movies.VerticalSlice.Api.Services
 {
     public interface IMovieService
     {
+        string? AuthToken { get; set; }
+
         Task<HttpResponseMessage> CreateAsync(MovieDto movie);
         Task<HttpResponseMessage> DeleteAsync(Guid id);
         Task<List<MovieDto>?> GetAllAsync();

--- a/Movies.VerticalSlice.Api.Services/Services/MovieService.cs
+++ b/Movies.VerticalSlice.Api.Services/Services/MovieService.cs
@@ -5,86 +5,87 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
-namespace Movies.VerticalSlice.Api.Services
+namespace Movies.VerticalSlice.Api.Services;
+
+public class MovieService : IMovieService
 {
-    public class MovieService : IMovieService
+    private readonly HttpClient _httpClient;
+
+    public string? AuthToken { get; set; }
+
+    public MovieService(IHttpClientFactory httpClientFactory)
     {
-        private readonly HttpClient _httpClient;
-        public string? AuthToken;
+        _httpClient = httpClientFactory.CreateClient("AuthorizedClient");
+    }
 
-        public MovieService(IHttpClientFactory httpClientFactory)
+    public async Task<List<MovieDto>?> GetAllAsync()
+    {
+        return await _httpClient.GetFromJsonAsync<List<MovieDto>>(ApiEndpoints.Movies.GetAll);
+    }
+
+    public async Task<HttpResponseMessage> CreateAsync(MovieDto movie)
+    {
+        SetAuth();
+
+        var movieToCreate = new CreateMovieRequest(
+            movie.Title,
+            movie.YearOfRelease,
+            movie.Genres
+        );
+        var response = await _httpClient.PostAsJsonAsync(ApiEndpoints.Movies.Create, movieToCreate);
+        CheckResponse(response);
+        return response;
+    }
+
+    
+    public async Task<HttpResponseMessage> UpdateAsync(Guid id, MovieDto movieToUpdate)
+    {
+        SetAuth();
+
+        var updateRequest = new UpdateMovieRequest(movieToUpdate.Title,
+          movieToUpdate.YearOfRelease,
+          movieToUpdate.Genres
+        );
+
+        var url = $"{ApiEndpoints.Movies.Update}?id={id}";
+        var response = await _httpClient.PutAsJsonAsync(url, updateRequest);
+        CheckResponse(response);
+        return response;
+
+    }
+
+    public async Task<HttpResponseMessage> DeleteAsync(Guid id)
+    {
+        SetAuth();
+        var url = $"{ApiEndpoints.Movies.Delete}?id={id}";
+        Console.WriteLine($"DeleteAsync URL: {_httpClient.BaseAddress}{url}");
+        var response = await _httpClient.DeleteAsync(url);
+
+        CheckResponse(response);
+        return response;
+
+    }
+
+    void CheckResponse(HttpResponseMessage response)
+    {
+        if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
         {
-            _httpClient = httpClientFactory.CreateClient("AuthorizedClient");
+            throw new UnauthorizedAccessException("User is not authorized.");
         }
-
-        public async Task<List<MovieDto>?> GetAllAsync()
+        if (response.StatusCode == System.Net.HttpStatusCode.BadRequest)
         {
-            return await _httpClient.GetFromJsonAsync<List<MovieDto>>(ApiEndpoints.Movies.GetAll);
+            throw new InvalidOperationException("Bad request.");
         }
-
-        public async Task<HttpResponseMessage> CreateAsync(MovieDto movie)
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
-            SetAuth();
-
-            var movieToCreate = new CreateMovieRequest(
-                movie.Title,
-                movie.YearOfRelease,
-                movie.Genres
-            );
-            var response = await _httpClient.PostAsJsonAsync(ApiEndpoints.Movies.Create, movieToCreate);
-            CheckResponse(response);
-            return response;
+            throw new InvalidOperationException("Not Found");
         }
-
-        
-        public async Task<HttpResponseMessage> UpdateAsync(Guid id, MovieDto movieToUpdate)
-        {
-            SetAuth();
-
-            var updateRequest = new UpdateMovieRequest(movieToUpdate.Title,
-              movieToUpdate.YearOfRelease,
-              movieToUpdate.Genres
-            );
-
-            var url = $"{ApiEndpoints.Movies.Update}?id={id}";
-            var response = await _httpClient.PutAsJsonAsync(url, updateRequest);
-            CheckResponse(response);
-            return response;
-
-        }
-
-        public async Task<HttpResponseMessage> DeleteAsync(Guid id)
-        {
-            SetAuth();
-            var url = $"{ApiEndpoints.Movies.Delete}?id={id}";
-            Console.WriteLine($"DeleteAsync URL: {_httpClient.BaseAddress}{url}");
-            var response = await _httpClient.DeleteAsync(url);
-
-            CheckResponse(response);
-            return response;
-
-        }
-
-        void CheckResponse(HttpResponseMessage response)
-        {
-            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
-            {
-                throw new UnauthorizedAccessException("User is not authorized.");
-            }
-            if (response.StatusCode == System.Net.HttpStatusCode.BadRequest)
-            {
-                throw new InvalidOperationException("Bad request.");
-            }
-            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
-            {
-                throw new InvalidOperationException("Not Found");
-            }
-        }
+    }
 
 
-        void SetAuth()
-        {
-            if (!string.IsNullOrEmpty(AuthToken))
-                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
-        }
+    void SetAuth()
+    {
+        if (!string.IsNullOrEmpty(AuthToken))
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AuthToken);
+    }
 }

--- a/Movies.VerticalSlice.Api.Wpf.Tests/MoviesViewModelTests.cs
+++ b/Movies.VerticalSlice.Api.Wpf.Tests/MoviesViewModelTests.cs
@@ -13,7 +13,8 @@ namespace Movies.VerticalSlice.Api.Wpf.Tests
         public void Constructor_InitializesMoviesCollection()
         {
             var movieServiceMock = new Mock<IMovieService>();
-            var viewModel = new MoviesViewModel(movieServiceMock.Object);
+            TokenStore tokenStore = new TokenStore();
+            var viewModel = new MoviesViewModel(movieServiceMock.Object,tokenStore);
             Assert.NotNull(viewModel.Movies);
             Assert.Empty(viewModel.Movies);
         }
@@ -30,8 +31,8 @@ namespace Movies.VerticalSlice.Api.Wpf.Tests
 
             var movieServiceMock = new Mock<IMovieService>();
             movieServiceMock.Setup(s => s.GetAllAsync()).ReturnsAsync(movies);
-
-            var viewModel = new MoviesViewModel(movieServiceMock.Object);
+            TokenStore tokenStore = new TokenStore();
+            var viewModel = new MoviesViewModel(movieServiceMock.Object, tokenStore );
 
             // Act
             await viewModel.LoadMoviesAsync();
@@ -53,8 +54,8 @@ namespace Movies.VerticalSlice.Api.Wpf.Tests
             };
             var movieServiceMock = new Mock<IMovieService>();
             movieServiceMock.Setup(s => s.GetAllAsync()).ReturnsAsync(movies);
-
-            var viewModel = new MoviesViewModel(movieServiceMock.Object);
+            TokenStore tokenStore = new TokenStore();
+            var viewModel = new MoviesViewModel(movieServiceMock.Object, tokenStore);
            
 
             var navServiceMock = new Mock<IRegionNavigationService>();

--- a/Movies.VerticalSlice.Api.Wpf/ViewModels/MoviesViewModel.cs
+++ b/Movies.VerticalSlice.Api.Wpf/ViewModels/MoviesViewModel.cs
@@ -17,10 +17,10 @@ namespace Movies.VerticalSlice.Api.Wpf.ViewModels
 {
     public class MoviesViewModel : BindableBase, INavigationAware
     {
-        private readonly IMovieService _movieService;
+
 
         #region "Properties"
-        readonly MovieService _movieService;
+        readonly IMovieService _movieService;
         readonly TokenStore _tokenStore;
         bool _isEditing;
         bool _isLoading;
@@ -66,7 +66,7 @@ namespace Movies.VerticalSlice.Api.Wpf.ViewModels
         }
 
         #endregion
-        public MoviesViewModel(MovieService movieService, TokenStore tokenStore)
+        public MoviesViewModel(IMovieService movieService, TokenStore tokenStore)
         {
             _movieService = movieService;
             _tokenStore = tokenStore;
@@ -123,14 +123,19 @@ namespace Movies.VerticalSlice.Api.Wpf.ViewModels
         }
         async void OnAddMovie(GridViewAddingNewEventArgs args)
         {
-            var newMovie = new MovieDto();
-            Movies.Add(newMovie);
+            MovieDto newMovie = AddNewMovieToCollection();
             SelectedMovie = newMovie;
             _movieService.AuthToken = _tokenStore.Token;
             await _movieService.CreateAsync(newMovie);
         }
 
-      
+        MovieDto AddNewMovieToCollection()
+        {
+            var newMovie = new MovieDto();
+            Movies.Add(newMovie);
+            return newMovie;
+        }
+
         async void OnDeleteMovie(IList selectedItems)
         {
             if (selectedItems == null || selectedItems.Count == 0)


### PR DESCRIPTION
Updated IMovieService to include a nullable AuthToken property for managing authentication. Modified MovieService to implement this property and set the authorization header in CreateAsync, UpdateAsync, and DeleteAsync methods. Refactored CheckResponse for better error handling. Changed MoviesViewModel to accept IMovieService for improved abstraction and updated tests accordingly. Refactored OnAddMovie for better code organization.