### PR TITLE
Add IMovieNamesProviderService for movie name management

### DIFF
--- a/Movies.VerticalSlice.Api.Services/Services/IMovieNamesProviderService.cs
+++ b/Movies.VerticalSlice.Api.Services/Services/IMovieNamesProviderService.cs
@@ -1,0 +1,13 @@
+﻿using Movies.VerticalSlice.Api.Shared.Dtos;
+using System.Collections.ObjectModel;
+
+namespace Movies.VerticalSlice.Api.Services
+{
+    public interface IMovieNamesProviderService
+    {
+        Task EnsureLoadedAsync();
+        Task RefreshAsync(); 
+        ObservableCollection<MovieNameDto> MovieNames { get; }
+        void Clear();
+    }
+}

--- a/Movies.VerticalSlice.Api.Services/Services/MovieNamesProviderService.cs
+++ b/Movies.VerticalSlice.Api.Services/Services/MovieNamesProviderService.cs
@@ -1,0 +1,41 @@
+﻿using Movies.VerticalSlice.Api.Shared.Dtos;
+using System.Collections.ObjectModel;
+
+namespace Movies.VerticalSlice.Api.Services
+{
+    public class MovieNamesProviderService : IMovieNamesProviderService
+    {
+        readonly IRatingsService _ratingsService;
+        bool _isLoaded;
+        public ObservableCollection<MovieNameDto> MovieNames { get; } = new ObservableCollection<MovieNameDto>();
+
+        public MovieNamesProviderService(IRatingsService ratingsService)
+        {
+            _ratingsService = ratingsService;
+        }
+
+        public void Clear()
+        {
+            MovieNames.Clear();
+            _isLoaded = false;
+        }
+
+        public async Task EnsureLoadedAsync()
+        {
+            if (_isLoaded) return;
+            var movieNames = await _ratingsService.GetAllMovieNamesAsync();
+            MovieNames.Clear();
+            if (movieNames != null)
+            {
+                foreach (var movie in movieNames)
+                    MovieNames.Add(movie);
+            }
+            _isLoaded = true;
+        }
+
+        public async Task RefreshAsync()
+        {
+           await EnsureLoadedAsync();
+        }
+    }
+}

--- a/Movies.VerticalSlice.Api.Wpf/App.xaml.cs
+++ b/Movies.VerticalSlice.Api.Wpf/App.xaml.cs
@@ -30,6 +30,7 @@ namespace Movies.VerticalSlice.Api.Wpf
             containerRegistry.RegisterSingleton<TokenStore>();
             containerRegistry.RegisterDialog<LoginWindow, LoginViewModel>("LoginWindow");
             containerRegistry.Register<IValidator<LoginViewModel>, LoginViewModelValidator>();
+            containerRegistry.RegisterSingleton<IMovieNamesProviderService, MovieNamesProviderService>();   
 
             var services = new ServiceCollection();
             services.AddHttpClient("AuthorizedClient", client =>

--- a/Movies.VerticalSlice.Api.Wpf/Views/RatingsView.xaml
+++ b/Movies.VerticalSlice.Api.Wpf/Views/RatingsView.xaml
@@ -42,8 +42,7 @@
                     <telerik:GridViewComboBoxColumn 
                     Header="Movie" DataMemberBinding="{Binding MovieId,Mode=TwoWay}"
                     ItemsSourceBinding="{Binding DataContext.MovieNames,RelativeSource={RelativeSource AncestorType=UserControl}}"
-                    DisplayMemberPath="MovieName" SelectedValueMemberPath="MovieId"
-                        
+                    DisplayMemberPath="MovieName" SelectedValueMemberPath="MovieId" 
                     Width="Auto">
                     </telerik:GridViewComboBoxColumn>
                     <telerik:GridViewDataColumn Header="Rating" DataMemberBinding="{Binding Rating}" />

--- a/Movies.VerticalSlice.Api/Features/Movies/GetAll/GetAllMoviesHandler.cs
+++ b/Movies.VerticalSlice.Api/Features/Movies/GetAll/GetAllMoviesHandler.cs
@@ -59,12 +59,7 @@ public class GetAllMoviesHandler : IRequestHandler<GetAllMoviesQuery, IEnumerabl
             moviesQuery = moviesQuery
                 .Take(query.Limit.Value);
         }
-        else         
-        {
-            moviesQuery = moviesQuery
-                .Take(100); // Default limit to prevent excessive data retrieval
-        }
-
+       
 
         var movies = await moviesQuery.AsNoTracking().ToListAsync(token);
 


### PR DESCRIPTION
Introduces the `IMovieNamesProviderService` interface and its implementation, `MovieNamesProviderService`, to manage movie names using an `ObservableCollection<MovieNameDto>`. Updates `App.xaml.cs` to register the service as a singleton. Modifies `MoviesViewModel` and `RatingsViewModel` to utilize the new service for refreshing movie names. Removes the `LoadMovieNamesAsync` method and updates bindings in `RatingsView.xaml`. Cleans up commented-out code in `GetAllMoviesHandler`. These changes improve code organization and maintainability.