### PR TITLE
Add Blazor login client tests and improve authentication flow closes #27

### DIFF
--- a/Movies.VerticalSlice.Api.Blazor.Client.Tests/Mocks/MockHttpClientFactory.cs
+++ b/Movies.VerticalSlice.Api.Blazor.Client.Tests/Mocks/MockHttpClientFactory.cs
@@ -1,0 +1,18 @@
+﻿namespace Movies.VerticalSlice.Api.Blazor.Client.Tests.Mocks;
+
+public class MockHttpClientFactory : IHttpClientFactory
+{
+    private readonly HttpMessageHandler _handler;
+    private readonly Uri _base;
+    public MockHttpClientFactory(HttpMessageHandler handler, Uri baseAddress)
+    {
+        _handler = handler;
+        _base = baseAddress;
+    }
+
+    public HttpClient CreateClient(string name)
+    {
+        var client = new HttpClient(_handler) { BaseAddress = _base };
+        return client;
+    }
+}

--- a/Movies.VerticalSlice.Api.Blazor.Client.Tests/Mocks/MockHttpMessageHandler.cs
+++ b/Movies.VerticalSlice.Api.Blazor.Client.Tests/Mocks/MockHttpMessageHandler.cs
@@ -1,0 +1,11 @@
+﻿public class MockHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+    public MockHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) => _handler = handler;
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        => Task.FromResult(_handler(request));
+}
+
+
+

--- a/Movies.VerticalSlice.Api.Blazor.Client.Tests/Movies.VerticalSlice.Api.Blazor.Client.Tests.csproj
+++ b/Movies.VerticalSlice.Api.Blazor.Client.Tests/Movies.VerticalSlice.Api.Blazor.Client.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="bunit" Version="2.1.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+	</ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Movies.VerticalSlice.Api.Blazor\Movies.VerticalSlice.Api.Blazor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Movies.VerticalSlice.Api.Blazor.Client.Tests/Page/LoginPageTests.cs
+++ b/Movies.VerticalSlice.Api.Blazor.Client.Tests/Page/LoginPageTests.cs
@@ -1,0 +1,140 @@
+﻿using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Movies.VerticalSlice.Api.Blazor.Authentication;
+using Movies.VerticalSlice.Api.Blazor.Client.Tests.Mocks;
+using Movies.VerticalSlice.Api.Blazor.Client.Tests.TestHelpers;
+using Movies.VerticalSlice.Api.Blazor.Pages;
+using Movies.VerticalSlice.Api.Shared.Responses;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace Movies.VerticalSlice.Api.Blazor.Client.Tests.Page;
+public partial class LoginPageTests : BunitContext
+{
+    [Fact]
+    public void Login_SetsToken()
+    {
+        (IRenderedComponent<Pages.Login> cut, TestJwtAuthenticationStateProvider auth) 
+            = Given_we_have_a_login_page();
+        When_we_click_login(cut);
+        Then_we_should_get_the_token_set(cut, auth); 
+    }
+
+    [Fact]
+    public void Login_Navigates_to_root()
+    {
+        (IRenderedComponent<Pages.Login> cut, TestJwtAuthenticationStateProvider auth)
+            = Given_we_have_a_login_page();
+        When_we_click_login(cut);
+        Then_we_should_navigate_to_the_root(cut);
+    }
+
+    [Fact]
+    public void Login_Failure_ShowsError()
+    {
+        var (cut, auth, _) = RenderWithHandler(HttpStatusCode.BadRequest);
+        When_we_click_login(cut);
+        Then_we_should_show_error(cut, auth);
+    }
+    [Fact]
+    public void Login_Success_Does_Not_Show_Error()
+    {
+        (IRenderedComponent<Pages.Login> cut, TestJwtAuthenticationStateProvider auth)
+            = Given_we_have_a_login_page();
+        When_we_click_login(cut);
+        Then_we_should_NOT_show_an_error(cut, auth);
+       
+    }
+
+   
+    (IRenderedComponent<Pages.Login> cut, TestJwtAuthenticationStateProvider auth)
+       Given_we_have_a_login_page()
+    {
+        var (cut, auth, _) = RenderWithHandler(HttpStatusCode.OK,
+            new LoginResult { Token = "valid_token" });
+
+        JSInterop.SetupVoid("localStorage.setItem", "authToken", "valid_token");
+        return (cut, auth);
+
+    }
+    void When_we_click_login(IRenderedComponent<Pages.Login> cut)
+    {
+        cut.Find("button").Click();
+    }
+
+    void Then_we_should_navigate_to_the_root(IRenderedComponent<Pages.Login> cut)
+    {
+        cut.WaitForAssertion(() =>
+        {
+            Assert.EndsWith("/", Services.GetRequiredService<NavigationManager>().Uri);
+        });
+    }
+
+    void Then_we_should_get_the_token_set(
+        IRenderedComponent<Pages.Login> cut,
+        TestJwtAuthenticationStateProvider auth)
+    {
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(auth.SetTokenCalled);
+            Assert.Equal("valid_token", auth.LastToken);
+        });
+    }
+
+    TestJwtAuthenticationStateProvider RegisterAuth()
+    {
+        var auth = new TestJwtAuthenticationStateProvider(JSInterop.JSRuntime);
+        Services.AddSingleton<JwtAuthenticationStateProvider>(auth);
+        return auth;
+    }
+
+    (
+        IRenderedComponent<Pages.Login> cut,
+        TestJwtAuthenticationStateProvider auth,
+        CapturingHttpHandler handler)
+        RenderWithHandler(HttpStatusCode code, LoginResult? result = null)
+    {
+        var handler = new CapturingHttpHandler(req =>
+        {
+            var response = new HttpResponseMessage(code)
+            {
+                Content = result is not null ? JsonContent.Create(result) : null
+            };
+            return Task.FromResult(response);
+        });
+
+        Services.AddSingleton<IHttpClientFactory>(
+            new MockHttpClientFactory(handler, new Uri("https://example.test/")));
+        var auth = RegisterAuth();
+        var cut = Render<Pages.Login>();
+        return (cut, auth, handler);
+    }
+
+    void Then_we_should_show_error(
+        IRenderedComponent<Pages.Login> cut,
+        TestJwtAuthenticationStateProvider auth)
+    {
+        cut.WaitForAssertion(() =>
+        {
+            Assert.False(auth.SetTokenCalled);
+            Assert.Contains("Invalid login", cut.Markup);
+        });
+    }
+
+    void Then_we_should_NOT_show_an_error(
+       IRenderedComponent<Login> cut,
+       TestJwtAuthenticationStateProvider auth)
+    {
+        cut.WaitForAssertion(() =>
+        {
+            Assert.DoesNotContain("Invalid login", cut.Markup);
+            Assert.True(auth.SetTokenCalled);
+            Assert.Equal("valid_token", auth.LastToken);
+        });
+    }
+
+
+
+}

--- a/Movies.VerticalSlice.Api.Blazor.Client.Tests/TestHelpers/CapturingHttpHandler.cs
+++ b/Movies.VerticalSlice.Api.Blazor.Client.Tests/TestHelpers/CapturingHttpHandler.cs
@@ -1,0 +1,26 @@
+﻿namespace Movies.VerticalSlice.Api.Blazor.Client.Tests.Page;
+public partial class LoginPageTests
+{
+    // Capturing handler and factory
+    public class CapturingHttpHandler : HttpMessageHandler
+    {
+        private Func<HttpRequestMessage, Task<HttpResponseMessage>> _responder;
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public string? LastRequestBody { get; private set; }
+
+        public CapturingHttpHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) => _responder = responder;
+
+        public void SetResponder(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) => _responder = responder;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            if (request.Content is not null)
+                LastRequestBody = await request.Content.ReadAsStringAsync(cancellationToken);
+            return await _responder(request);
+        }
+    }
+}
+
+
+

--- a/Movies.VerticalSlice.Api.Blazor.Client.Tests/TestHelpers/TestJwtAuthenticationProvider.cs
+++ b/Movies.VerticalSlice.Api.Blazor.Client.Tests/TestHelpers/TestJwtAuthenticationProvider.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.JSInterop;
+using Movies.VerticalSlice.Api.Blazor.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Movies.VerticalSlice.Api.Blazor.Client.Tests.TestHelpers;
+
+public class TestJwtAuthenticationStateProvider : JwtAuthenticationStateProvider
+{
+    public string? LastToken { get; private set; }
+    public bool SetTokenCalled { get; private set; }
+
+    public TestJwtAuthenticationStateProvider(IJSRuntime js) : base(js) { }
+
+    public override async Task SetTokenAsync(string token)
+    {
+        SetTokenCalled = true;
+        LastToken = token;
+        await base.SetTokenAsync(token);
+    }
+}

--- a/Movies.VerticalSlice.Api.Blazor/Authentication/JwtAuthenticationStateProvider.cs
+++ b/Movies.VerticalSlice.Api.Blazor/Authentication/JwtAuthenticationStateProvider.cs
@@ -22,7 +22,7 @@ public class JwtAuthenticationStateProvider : AuthenticationStateProvider
         return new AuthenticationState(new ClaimsPrincipal(identity));
     }
 
-    public async Task SetTokenAsync(string token)
+    public virtual async Task SetTokenAsync(string token)
     {
         if (string.IsNullOrWhiteSpace(token))
             await _js.InvokeVoidAsync("localStorage.removeItem", TokenKey);

--- a/Movies.VerticalSlice.Api.Blazor/Pages/Login.razor
+++ b/Movies.VerticalSlice.Api.Blazor/Pages/Login.razor
@@ -1,5 +1,6 @@
 ﻿@page "/login"
 @using global::Movies.VerticalSlice.Api.Blazor.Authentication
+@using global::Movies.VerticalSlice.Api.Shared.Constants
 @using global::Movies.VerticalSlice.Api.Shared.Responses
 @inject IHttpClientFactory HttpClientFactory
 @inject JwtAuthenticationStateProvider AuthProvider
@@ -17,7 +18,7 @@
     HttpClient Http => HttpClientFactory.CreateClient("AuthorizedClient");
     private async Task LoginAsync()
     {
-        var response = await Http.PostAsJsonAsync("api/users/login", new { Email = email, Password = password });
+        var response = await Http.PostAsJsonAsync(ApiEndpoints.Users.Login, new { Email = email, Password = password });
         if (response.IsSuccessStatusCode)
         {
             var result = await response.Content.ReadFromJsonAsync<LoginResult>();

--- a/Movies.VerticalSlice.Api.Blazor/Pages/Ratings.razor
+++ b/Movies.VerticalSlice.Api.Blazor/Pages/Ratings.razor
@@ -1,4 +1,5 @@
 ﻿@page "/ratings"  
+@using Microsoft.AspNetCore.Authorization
 @using Telerik.Blazor
 @using Telerik.Blazor.Components  
 @using Telerik.DataSource
@@ -6,6 +7,9 @@
 @using global::Movies.VerticalSlice.Api.Shared.Dtos  
 @inject IHttpClientFactory HttpClientFactory  
 @inject RatingsService RatingsService 
+@attribute [Authorize]
+@inject NavigationManager Navigation
+@inject AuthenticationStateProvider AuthStateProvider
 
 <TelerikGrid Data="@ratings"
              Pageable="true"
@@ -112,6 +116,11 @@
     }
     protected override async Task OnInitializedAsync()  
     {  
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        if (authState.User?.Identity == null || !authState.User.Identity.IsAuthenticated)
+        {
+            Navigation.NavigateTo("/login", true);
+        }
         await LoadRatingsAsync();  
     }  
 

--- a/Movies.VerticalSlice.sln
+++ b/Movies.VerticalSlice.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Movies.VerticalSlice.Api.Wp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Movies.VerticalSlice.Api.Wpf.Tests", "Movies.VerticalSlice.Api.Wpf.Tests\Movies.VerticalSlice.Api.Wpf.Tests.csproj", "{E2E0F31A-66D6-4295-8A22-902A5D0899FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Movies.VerticalSlice.Api.Blazor.Client.Tests", "Movies.VerticalSlice.Api.Blazor.Client.Tests\Movies.VerticalSlice.Api.Blazor.Client.Tests.csproj", "{6C38932F-123B-446B-A18E-04B7558D9E54}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{E2E0F31A-66D6-4295-8A22-902A5D0899FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E2E0F31A-66D6-4295-8A22-902A5D0899FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E2E0F31A-66D6-4295-8A22-902A5D0899FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C38932F-123B-446B-A18E-04B7558D9E54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C38932F-123B-446B-A18E-04B7558D9E54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C38932F-123B-446B-A18E-04B7558D9E54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C38932F-123B-446B-A18E-04B7558D9E54}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Introduced a new test project `Movies.VerticalSlice.Api.Blazor.Client.Tests` targeting .NET 8.0, with test libraries xUnit and bUnit  Added `MockHttpClientFactory`, `MockHttpMessageHandler`, and `CapturingHttpHandler` for HTTP testing. Created `LoginPageTests` to validate login functionality, including token handling and navigation.

Enhanced `JwtAuthenticationStateProvider` by making `SetTokenAsync` virtual for testability. Added `TestJwtAuthenticationStateProvider` for authentication-related tests.