### PR TITLE
Refactor to use interfaces for DI in services

### DIFF
--- a/Movies.VerticalSlice.Api.Blazor/Pages/Movies.razor
+++ b/Movies.VerticalSlice.Api.Blazor/Pages/Movies.razor
@@ -5,7 +5,7 @@
 @using global::Movies.VerticalSlice.Api.Shared.Dtos
 
 @inject IHttpClientFactory HttpClientFactory
-@inject MovieService MovieService
+@inject IMovieService MovieService
 <PageTitle>Movies</PageTitle>
 
 <h2>Movies</h2>

--- a/Movies.VerticalSlice.Api.Blazor/Pages/Ratings.razor
+++ b/Movies.VerticalSlice.Api.Blazor/Pages/Ratings.razor
@@ -6,7 +6,7 @@
 @using global::Movies.VerticalSlice.Api.Services  
 @using global::Movies.VerticalSlice.Api.Shared.Dtos  
 @inject IHttpClientFactory HttpClientFactory  
-@inject RatingsService RatingsService 
+@inject IRatingsService RatingsService 
 @attribute [Authorize]
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthStateProvider

--- a/Movies.VerticalSlice.Api.Blazor/Program.cs
+++ b/Movies.VerticalSlice.Api.Blazor/Program.cs
@@ -21,8 +21,8 @@ builder.Services.AddHttpClient("AuthorizedClient", client =>
     client.BaseAddress = new Uri("https://localhost:7299/");
 }).AddHttpMessageHandler<JwtAuthorizationMessageHandler>();
 
-builder.Services.AddScoped<MovieService>();
-builder.Services.AddScoped<RatingsService>();
+builder.Services.AddScoped<IMovieService, MovieService>();
+builder.Services.AddScoped<IRatingsService, RatingsService>();
 
 // Register Telerik
 builder.Services.AddTelerikBlazor();


### PR DESCRIPTION
Replaced `MovieService` and `RatingsService` with their respective interfaces (`IMovieService` and `IRatingsService`) in `Movies.razor` and `Ratings.razor` to adhere to the Dependency Inversion Principle.

Updated `Program.cs` to register interfaces with their implementations for dependency injection, improving modularity, testability, and maintainability.