### PR TITLE
Refactor tests to use helpers; fix logger and UTC usage

### DIFF
--- a/Movies.Api.VerticalSlice.Api.Tests/Handlers/DeleteRatingHandlerTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Handlers/DeleteRatingHandlerTests.cs
@@ -74,11 +74,7 @@ public class DeleteRatingHandlerTests
     (DeleteRatingHandler handler, MoviesDbContext context) And_we_have_a_handler_with_existing_rating(
         Guid ratingId)
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -102,20 +98,14 @@ public class DeleteRatingHandlerTests
         context.Ratings.Add(rating);
         context.SaveChanges();
 
-        var mockLogger = new Mock<ILogger<DeleteRatingHandler>>();
-        var handler = new DeleteRatingHandler(context, mockLogger.Object);
-
+        var handler = CreateHandler(context);
         return (handler, context);
     }
 
     (DeleteRatingHandler handler, MoviesDbContext context, Mock<ILogger<DeleteRatingHandler>> mockLogger) 
         And_we_have_a_handler_with_existing_rating_and_logger(Guid ratingId)
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -147,26 +137,15 @@ public class DeleteRatingHandlerTests
 
     (DeleteRatingHandler handler, MoviesDbContext context) And_we_have_a_handler_without_rating()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
-
-        var mockLogger = new Mock<ILogger<DeleteRatingHandler>>();
-        var handler = new DeleteRatingHandler(context, mockLogger.Object);
-
+        var context = CreateTestContext();
+        var handler = CreateHandler(context);
         return (handler, context);
     }
 
     (DeleteRatingHandler handler, MoviesDbContext context, Mock<ILogger<DeleteRatingHandler>> mockLogger) 
         And_we_have_a_handler_without_rating_and_logger()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var mockLogger = new Mock<ILogger<DeleteRatingHandler>>();
         var handler = new DeleteRatingHandler(context, mockLogger.Object);
@@ -177,11 +156,7 @@ public class DeleteRatingHandlerTests
     (DeleteRatingHandler handler, MoviesDbContext context, Guid otherRatingId) 
         And_we_have_a_handler_with_multiple_ratings(Guid targetRatingId)
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -217,9 +192,7 @@ public class DeleteRatingHandlerTests
         context.Ratings.Add(otherRating);
         context.SaveChanges();
 
-        var mockLogger = new Mock<ILogger<DeleteRatingHandler>>();
-        var handler = new DeleteRatingHandler(context, mockLogger.Object);
-
+        var handler = CreateHandler(context);
         return (handler, context, otherRatingId);
     }
 
@@ -289,5 +262,21 @@ public class DeleteRatingHandlerTests
 
         var otherRating = context.Ratings.FirstOrDefault(r => r.Id == otherRatingId);
         otherRating.Should().NotBeNull();
+    }
+
+    // Helper methods to reduce duplication
+    private MoviesDbContext CreateTestContext()
+    {
+        var options = new DbContextOptionsBuilder<MoviesDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new MoviesDbContext(options);
+    }
+
+    private DeleteRatingHandler CreateHandler(MoviesDbContext context)
+    {
+        var mockLogger = new Mock<ILogger<DeleteRatingHandler>>();
+        return new DeleteRatingHandler(context, mockLogger.Object);
     }
 }

--- a/Movies.Api.VerticalSlice.Api.Tests/Handlers/GetAllRatingsHandlerTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Handlers/GetAllRatingsHandlerTests.cs
@@ -82,11 +82,7 @@ public class GetAllRatingsHandlerTests
 
     (GetAllRatingsHandler handler, MoviesDbContext context) And_we_have_a_handler_with_multiple_ratings()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie1 = new Movie
         {
@@ -161,33 +157,20 @@ public class GetAllRatingsHandlerTests
         context.Ratings.AddRange(rating1, rating2, rating3);
         context.SaveChanges();
 
-        var mockLogger = new Mock<ILogger<GetAllRatingsHandler>>();
-        var handler = new GetAllRatingsHandler(context, mockLogger.Object);
-
+        var handler = CreateHandler(context);
         return (handler, context);
     }
 
     (GetAllRatingsHandler handler, MoviesDbContext context) And_we_have_a_handler_without_ratings()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
-
-        var mockLogger = new Mock<ILogger<GetAllRatingsHandler>>();
-        var handler = new GetAllRatingsHandler(context, mockLogger.Object);
-
+        var context = CreateTestContext();
+        var handler = CreateHandler(context);
         return (handler, context);
     }
 
     (GetAllRatingsHandler handler, MoviesDbContext context) And_we_have_a_handler_with_single_rating()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -219,20 +202,14 @@ public class GetAllRatingsHandlerTests
         context.Ratings.Add(rating);
         context.SaveChanges();
 
-        var mockLogger = new Mock<ILogger<GetAllRatingsHandler>>();
-        var handler = new GetAllRatingsHandler(context, mockLogger.Object);
-
+        var handler = CreateHandler(context);
         return (handler, context);
     }
 
     (GetAllRatingsHandler handler, MoviesDbContext context, Mock<ILogger<GetAllRatingsHandler>> mockLogger) 
         And_we_have_a_handler_with_ratings_and_logger()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -331,5 +308,21 @@ public class GetAllRatingsHandlerTests
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
+    }
+
+    // Helper methods to reduce duplication
+    private MoviesDbContext CreateTestContext()
+    {
+        var options = new DbContextOptionsBuilder<MoviesDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new MoviesDbContext(options);
+    }
+
+    private GetAllRatingsHandler CreateHandler(MoviesDbContext context)
+    {
+        var mockLogger = new Mock<ILogger<GetAllRatingsHandler>>();
+        return new GetAllRatingsHandler(context, mockLogger.Object);
     }
 }

--- a/Movies.Api.VerticalSlice.Api.Tests/Handlers/RatingsCreateHandlerTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Handlers/RatingsCreateHandlerTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Movies.VerticalSlice.Api.Data.Database;
 using Movies.VerticalSlice.Api.Data.Models;
-using Movies.VerticalSlice.Api.Features.Movies.Update;
 using Movies.VerticalSlice.Api.Features.Ratings.Create;
 using Xunit;
 
@@ -92,11 +91,7 @@ public class RatingsCreateHandlerTests
 
     (RatingsCreateHandler handler, MoviesDbContext context) And_we_have_a_handler_with_valid_movie()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -118,37 +113,20 @@ public class RatingsCreateHandlerTests
         context.Users.Add(user);
         context.SaveChanges();
 
-        var validator = new RatingsCreateValidator(context);
-        var mockLogger = new Mock<ILogger<UpdateMovieHandler>>();
-
-        var handler = new RatingsCreateHandler(context, validator, mockLogger.Object);
-
+        var handler = CreateHandler(context);
         return (handler, context);
     }
 
     (RatingsCreateHandler handler, MoviesDbContext context) And_we_have_a_handler_without_movie()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
-
-        var validator = new RatingsCreateValidator(context);
-        var mockLogger = new Mock<ILogger<UpdateMovieHandler>>();
-
-        var handler = new RatingsCreateHandler(context, validator, mockLogger.Object);
-
+        var context = CreateTestContext();
+        var handler = CreateHandler(context);
         return (handler, context);
     }
 
     (RatingsCreateHandler handler, MoviesDbContext context) And_we_have_a_handler_with_existing_rating()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -180,11 +158,7 @@ public class RatingsCreateHandlerTests
         context.Ratings.Add(existingRating);
         context.SaveChanges();
 
-        var validator = new RatingsCreateValidator(context);
-        var mockLogger = new Mock<ILogger<UpdateMovieHandler>>();
-
-        var handler = new RatingsCreateHandler(context, validator, mockLogger.Object);
-
+        var handler = CreateHandler(context);
         return (handler, context);
     }
 
@@ -220,5 +194,22 @@ public class RatingsCreateHandlerTests
     {
         await Assert.ThrowsAsync<ValidationException>(
             () => handler.Handle(command, CancellationToken.None));
+    }
+
+    // Helper methods to reduce duplication
+    private MoviesDbContext CreateTestContext()
+    {
+        var options = new DbContextOptionsBuilder<MoviesDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new MoviesDbContext(options);
+    }
+
+    private RatingsCreateHandler CreateHandler(MoviesDbContext context)
+    {
+        var validator = new RatingsCreateValidator(context);
+        var mockLogger = new Mock<ILogger<RatingsCreateHandler>>();
+        return new RatingsCreateHandler(context, validator, mockLogger.Object);
     }
 }

--- a/Movies.Api.VerticalSlice.Api.Tests/Validators/RatingsCreateValidatorTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Validators/RatingsCreateValidatorTests.cs
@@ -138,11 +138,7 @@ public class RatingsCreateValidatorTests
 
     RatingsCreateValidator And_we_have_a_validator_with_valid_movie()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -161,22 +157,13 @@ public class RatingsCreateValidatorTests
 
     RatingsCreateValidator And_we_have_a_validator_without_movie()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
-
+        var context = CreateTestContext();
         return new RatingsCreateValidator(context);
     }
 
     RatingsCreateValidator And_we_have_a_validator_with_existing_rating()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -205,11 +192,7 @@ public class RatingsCreateValidatorTests
 
     RatingsCreateValidator And_we_have_a_validator_with_rating_for_different_user()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -265,5 +248,15 @@ public class RatingsCreateValidatorTests
     {
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Rating");
+    }
+
+    // Helper method to reduce duplication
+    private MoviesDbContext CreateTestContext()
+    {
+        var options = new DbContextOptionsBuilder<MoviesDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new MoviesDbContext(options);
     }
 }

--- a/Movies.Api.VerticalSlice.Api.Tests/Validators/RatingsUpdateValidatorTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Validators/RatingsUpdateValidatorTests.cs
@@ -144,11 +144,7 @@ public class RatingsUpdateValidatorTests
 
     RatingsUpdateValidator And_we_have_a_validator_with_valid_rating_and_movie()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -177,11 +173,7 @@ public class RatingsUpdateValidatorTests
 
     RatingsUpdateValidator And_we_have_a_validator_without_rating()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie = new Movie
         {
@@ -200,11 +192,7 @@ public class RatingsUpdateValidatorTests
 
     RatingsUpdateValidator And_we_have_a_validator_with_rating_but_no_movie()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var rating = new MovieRating
         {
@@ -223,11 +211,7 @@ public class RatingsUpdateValidatorTests
 
     RatingsUpdateValidator And_we_have_a_validator_with_rating_and_multiple_movies()
     {
-        var options = new DbContextOptionsBuilder<MoviesDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        var context = new MoviesDbContext(options);
+        var context = CreateTestContext();
 
         var movie1 = new Movie
         {
@@ -292,5 +276,15 @@ public class RatingsUpdateValidatorTests
     {
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Rating");
+    }
+
+    // Helper method to reduce duplication
+    private MoviesDbContext CreateTestContext()
+    {
+        var options = new DbContextOptionsBuilder<MoviesDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new MoviesDbContext(options);
     }
 }

--- a/Movies.VerticalSlice.Api/Features/Ratings/Create/RatingsCreateHandler.cs
+++ b/Movies.VerticalSlice.Api/Features/Ratings/Create/RatingsCreateHandler.cs
@@ -12,12 +12,12 @@ public class RatingsCreateHandler : IRequestHandler<RatingsCreateCommand, Guid>
 {
     private readonly MoviesDbContext _context;
     private readonly IValidator<RatingsCreateCommand> _validator;
-    private readonly ILogger<UpdateMovieHandler> _logger;
+    private readonly ILogger<RatingsCreateHandler> _logger;
 
     public RatingsCreateHandler(
         MoviesDbContext context, 
         IValidator<RatingsCreateCommand> validator, 
-        ILogger<UpdateMovieHandler> logger)
+        ILogger<RatingsCreateHandler> logger)
     {
         _context = context;
         _validator = validator;

--- a/Movies.VerticalSlice.Api/Features/Ratings/Update/RatingsUpdateHandler.cs
+++ b/Movies.VerticalSlice.Api/Features/Ratings/Update/RatingsUpdateHandler.cs
@@ -35,7 +35,7 @@ public class RatingsUpdateHandler : IRequestHandler<RatingsUpdateCommand, bool>
         {
             existingRating.MovieId = command.MovieId;
             existingRating.Rating = command.Rating;
-            existingRating.DateUpdated = DateTime.Now;
+            existingRating.DateUpdated = DateTime.UtcNow;
            
         }
         var affectedRows = await _context.SaveChangesAsync(cancellationToken);


### PR DESCRIPTION
Refactored test classes to use helper methods for creating in-memory contexts and handlers/services, reducing code duplication. Updated RatingsCreateHandler to use the correct logger type. Changed RatingsUpdateHandler to use DateTime.UtcNow for DateUpdated. Improves maintainability and consistency.