### PR TITLE
Add API request logging middleware and log querying endpoint

### DIFF
--- a/Movies.VerticalSlice.Api/Configuration/SecurityRequirementsOperationFilter.cs
+++ b/Movies.VerticalSlice.Api/Configuration/SecurityRequirementsOperationFilter.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Movies.VerticalSlice.Api.Configuration;
+
+public class SecurityRequirementsOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        // Check if the endpoint has [Authorize] attribute or RequireAuthorization()
+        var hasAuthorize = context.MethodInfo.DeclaringType?
+            .GetCustomAttributes(true)
+            .OfType<AuthorizeAttribute>()
+            .Any() ?? false;
+
+        if (!hasAuthorize)
+        {
+            hasAuthorize = context.MethodInfo
+                .GetCustomAttributes(true)
+                .OfType<AuthorizeAttribute>()
+                .Any();
+        }
+
+        // Check metadata for authorization requirement (for minimal APIs)
+        var metadata = context.ApiDescription.ActionDescriptor.EndpointMetadata;
+        var requiresAuth = metadata.OfType<AuthorizeAttribute>().Any();
+        var allowsAnonymous = metadata.OfType<AllowAnonymousAttribute>().Any();
+
+        // If endpoint requires authorization and doesn't explicitly allow anonymous
+        if ((hasAuthorize || requiresAuth) && !allowsAnonymous)
+        {
+            operation.Security = new List<OpenApiSecurityRequirement>
+            {
+                new OpenApiSecurityRequirement
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme,
+                                Id = "Bearer"
+                            }
+                        },
+                        Array.Empty<string>()
+                    }
+                }
+            };
+
+            // Add 401 response if not already present
+            if (!operation.Responses.ContainsKey("401"))
+            {
+                operation.Responses.Add("401", new OpenApiResponse 
+                { 
+                    Description = "Unauthorized - Authentication required" 
+                });
+            }
+        }
+    }
+}

--- a/Movies.VerticalSlice.Api/Features/Logging/GetAll/GetAllLogsEndpoint.cs
+++ b/Movies.VerticalSlice.Api/Features/Logging/GetAll/GetAllLogsEndpoint.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Movies.VerticalSlice.Api.Data.Database;
+using Movies.VerticalSlice.Api.Data.Models;
+
+namespace Movies.VerticalSlice.Api.Features.Logging.GetAll;
+
+public static class GetAllLogsEndpoint
+{
+    public static void MapGetAllLogs(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/logs", async (
+            MoviesDbContext db,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 50,
+            [FromQuery] string? level = null,
+            [FromQuery] string? category = null,
+            [FromQuery] DateTime? startDate = null,
+            [FromQuery] DateTime? endDate = null) =>
+        {
+            var query = db.ApplicationLogs.AsQueryable();
+
+            // Apply filters
+            if (!string.IsNullOrEmpty(level))
+            {
+                query = query.Where(l => l.Level == level);
+            }
+
+            if (!string.IsNullOrEmpty(category))
+            {
+                query = query.Where(l => l.Category == category);
+            }
+
+            if (startDate.HasValue)
+            {
+                query = query.Where(l => l.Timestamp >= startDate.Value);
+            }
+
+            if (endDate.HasValue)
+            {
+                query = query.Where(l => l.Timestamp <= endDate.Value);
+            }
+
+            // Get total count
+            var totalCount = await query.CountAsync();
+
+            // Apply pagination
+            var logs = await query
+                .OrderByDescending(l => l.Timestamp)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .Select(l => new
+                {
+                    l.Id,
+                    l.Timestamp,
+                    l.Level,
+                    l.Category,
+                    l.Message,
+                    l.Exception,
+                    l.UserId,
+                    l.UserName,
+                    l.RequestPath,
+                    l.Properties
+                })
+                .ToListAsync();
+
+            return Results.Ok(new
+            {
+                TotalCount = totalCount,
+                Page = page,
+                PageSize = pageSize,
+                TotalPages = (int)Math.Ceiling(totalCount / (double)pageSize),
+                Logs = logs
+            });
+        })
+        .WithName("GetAllLogs")
+        .WithTags("Logging")
+        .WithOpenApi()
+        .RequireAuthorization()
+        .Produces<object>(StatusCodes.Status200OK);
+    }
+}

--- a/Movies.VerticalSlice.Api/Features/Logging/README.md
+++ b/Movies.VerticalSlice.Api/Features/Logging/README.md
@@ -1,0 +1,165 @@
+# API Request Logging to Database
+
+## Overview
+All API requests are now automatically logged to the `ApplicationLogs` database table.
+
+## What Gets Logged
+- ? **Request Method** (GET, POST, PUT, DELETE, etc.)
+- ? **Request Path** (e.g., `/api/movies`)
+- ? **Query String** parameters
+- ? **Request Body** (up to 4000 characters)
+- ? **Response Status Code** (200, 404, 500, etc.)
+- ? **Response Body** (up to 4000 characters)
+- ? **Duration** (how long the request took in milliseconds)
+- ? **User ID** (from JWT token if authenticated)
+- ? **User Name** (from JWT token if authenticated)
+- ? **Timestamp** (when the request occurred)
+- ? **Exception Details** (if an error occurred)
+
+## Implementation Details
+
+### Middleware
+- **File**: `Movies.VerticalSlice.Api/Middleware/ApiRequestLoggingMiddleware.cs`
+- Automatically logs every API request to the database
+- Skips logging for static files, Swagger, and health checks
+- Logs are saved asynchronously to avoid slowing down requests
+
+### Database Table
+- **Table**: `ApplicationLogs`
+- **Model**: `Movies.VerticalSlice.Api.Data/Models/ApplicationLog.cs`
+
+### Log Levels
+- **Information**: Successful requests (2xx status codes)
+- **Warning**: Client errors (4xx status codes)
+- **Error**: Server errors (5xx status codes) or exceptions
+
+## API Endpoints
+
+### Get All Logs
+```http
+GET /api/logs?page=1&pageSize=50&level=Error&category=ApiRequest&startDate=2025-01-01
+```
+
+**Parameters:**
+- `page` (optional, default: 1) - Page number
+- `pageSize` (optional, default: 50) - Number of logs per page
+- `level` (optional) - Filter by log level (Information, Warning, Error)
+- `category` (optional) - Filter by category (e.g., "ApiRequest")
+- `startDate` (optional) - Filter logs from this date
+- `endDate` (optional) - Filter logs up to this date
+
+**Authorization**: Required (JWT token)
+
+### Create Custom Log
+```http
+POST /api/logs
+```
+
+**Body:**
+```json
+{
+  "level": "Information",
+  "category": "CustomCategory",
+  "message": "Custom log message",
+  "exception": null,
+  "requestPath": "/custom/path",
+  "properties": "{\"key\":\"value\"}"
+}
+```
+
+**Authorization**: Anonymous (no authentication required)
+
+## Querying Logs in SQL
+
+### Recent API Requests
+```sql
+SELECT TOP 100 
+    Timestamp, 
+    Level, 
+    Message, 
+    UserName,
+    RequestPath
+FROM ApplicationLogs
+WHERE Category = 'ApiRequest'
+ORDER BY Timestamp DESC
+```
+
+### Failed Requests
+```sql
+SELECT 
+    Timestamp, 
+    Message, 
+    Exception,
+    UserName,
+    RequestPath
+FROM ApplicationLogs
+WHERE Level = 'Error' AND Category = 'ApiRequest'
+ORDER BY Timestamp DESC
+```
+
+### Request Statistics
+```sql
+SELECT 
+    RequestPath,
+    COUNT(*) as RequestCount,
+    AVG(CAST(JSON_VALUE(Properties, '$.Duration') AS INT)) as AvgDurationMs
+FROM ApplicationLogs
+WHERE Category = 'ApiRequest'
+GROUP BY RequestPath
+ORDER BY RequestCount DESC
+```
+
+### Request Statistics by User
+```sql
+SELECT 
+    UserName,
+    COUNT(*) as RequestCount,
+    AVG(CAST(JSON_VALUE(Properties, '$.Duration') AS INT)) as AvgDurationMs
+FROM ApplicationLogs
+WHERE Category = 'ApiRequest' AND UserName IS NOT NULL
+GROUP BY UserName
+ORDER BY RequestCount DESC
+```
+
+### Recent Requests by Specific User
+```sql
+SELECT 
+    Timestamp, 
+    Message,
+    RequestPath,
+    JSON_VALUE(Properties, '$.Duration') as Duration,
+    JSON_VALUE(Properties, '$.StatusCode') as StatusCode
+FROM ApplicationLogs
+WHERE Category = 'ApiRequest' 
+  AND UserName = 'YourUsername'
+ORDER BY Timestamp DESC
+```
+
+## Configuration
+
+In `Program.cs`:
+```csharp
+app.UseHttpsRedirection();
+app.UseCors("AllowBlazorClient");
+app.UseAuthentication();
+app.UseAuthorization();
+
+// Custom API request logging middleware (logs to database)
+// MUST be after UseAuthentication() to have access to authenticated user
+app.UseMiddleware<ApiRequestLoggingMiddleware>();
+```
+
+**Important**: The middleware **must be placed AFTER** `UseAuthentication()` and `UseAuthorization()` to have access to the authenticated user's claims from the JWT token. This ensures the correct user ID and username are logged.
+
+## Performance Notes
+- Logging is done asynchronously (fire-and-forget) to avoid blocking API requests
+- Request and response bodies are limited to 4000 characters
+- Static files and Swagger endpoints are excluded from logging
+- Consider adding database cleanup jobs for old logs to prevent table growth
+
+## Testing in Swagger
+
+See [SWAGGER-TESTING.md](./SWAGGER-TESTING.md) for detailed instructions on:
+- How to authenticate in Swagger
+- Understanding which endpoints require authentication (padlock icons)
+- Verifying that user information is correctly logged to the database

--- a/Movies.VerticalSlice.Api/Features/Logging/SWAGGER-TESTING.md
+++ b/Movies.VerticalSlice.Api/Features/Logging/SWAGGER-TESTING.md
@@ -1,0 +1,104 @@
+# Testing API with Swagger
+
+## How to Authenticate in Swagger
+
+### Step 1: Register or Login
+
+1. **Register a new user** (if you don't have one):
+   - Find the `POST /api/users/register` endpoint (no padlock - doesn't require auth)
+   - Click "Try it out"
+   - Enter:
+     ```json
+     {
+       "userName": "testuser",
+       "email": "test@example.com",
+       "password": "YourPassword123!"
+     }
+     ```
+   - Click "Execute"
+
+2. **Login to get a JWT token**:
+   - Find the `POST /api/users/login` endpoint (no padlock - doesn't require auth)
+   - Click "Try it out"
+   - Enter:
+     ```json
+     {
+       "email": "test@example.com",
+       "password": "YourPassword123!"
+     }
+     ```
+   - Click "Execute"
+   - **Copy the `token` value from the response**
+
+### Step 2: Authorize in Swagger
+
+1. Click the **"Authorize"** button at the top right of the Swagger page (or click any padlock icon)
+2. In the "Value" field, enter: `Bearer YOUR_TOKEN_HERE`
+   - Example: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...`
+   - **Important**: Include the word "Bearer" followed by a space, then your token
+3. Click "Authorize"
+4. Click "Close"
+
+### Step 3: Test Protected Endpoints
+
+Now you can test any endpoint that has a padlock icon:
+- `GET /api/movies` - Get all movies
+- `POST /api/movies` - Create a movie
+- `DELETE /api/movies/{id}` - Delete a movie
+- etc.
+
+## Visual Indicators in Swagger
+
+### ?? No Padlock = Public Endpoint
+These endpoints don't require authentication:
+- `POST /api/users/register` - Register new user
+- `POST /api/users/login` - Login
+- `POST /api/logs` - Create log (anonymous logging allowed)
+
+### ?? Padlock = Protected Endpoint
+These endpoints require authentication (JWT token):
+- All movie CRUD operations
+- All rating operations
+- User profile operations
+- `GET /api/logs` - View logs
+
+## Testing User Logging in Database
+
+1. **Login** using the login endpoint to get a token
+2. **Authorize** in Swagger using your token
+3. **Make any API request** (e.g., GET /api/movies)
+4. **Check the database**:
+   ```sql
+   SELECT TOP 10 
+       Timestamp,
+       Message,
+       UserId,
+       UserName,
+       RequestPath
+   FROM ApplicationLogs
+   WHERE Category = 'ApiRequest'
+   ORDER BY Timestamp DESC
+   ```
+
+You should now see:
+- ? Your **UserId** (GUID from JWT token)
+- ? Your **UserName** (e.g., "testuser")
+- ? Request details
+
+## Troubleshooting
+
+### "Unauthorized" Response
+- Make sure you copied the entire token
+- Make sure you included "Bearer " before the token
+- Check if your token has expired (default: 60 minutes)
+- Try logging in again to get a fresh token
+
+### User Info Not Logged
+- Make sure you're **authenticated** when making the request
+- Check that the middleware is placed **after** `UseAuthentication()` in Program.cs
+- Look for debug logs in the output window showing "Authenticated user - UserId: ..."
+
+### Can't See Which Endpoints Require Auth
+- Endpoints with a ?? padlock icon require authentication
+- Endpoints without a padlock are public
+- After authenticating, all padlocks should show as "Authorized"

--- a/Movies.VerticalSlice.Api/Features/Users/Login/LoginEndpoint.cs
+++ b/Movies.VerticalSlice.Api/Features/Users/Login/LoginEndpoint.cs
@@ -26,6 +26,7 @@ public static class LoginEndpoint
                 return Results.BadRequest(ex.Message);
             }
         })
+        .AllowAnonymous()
         .WithName("LoginUser")
         .WithTags("Users")
         .WithSummary("Login user")

--- a/Movies.VerticalSlice.Api/Features/Users/Register/RegisterUserEndpoint.cs
+++ b/Movies.VerticalSlice.Api/Features/Users/Register/RegisterUserEndpoint.cs
@@ -29,8 +29,13 @@ public static class RegisterUserEndpoint
                 return Results.BadRequest(new { success = false, message = ex.Message });
             }
         })
+        .AllowAnonymous()
         .WithName("RegisterUser")
         .WithTags("Users")
-        .WithOpenApi();
+        .WithSummary("Register new user")
+        .WithDescription("Create a new user account")
+        .WithOpenApi()
+        .Produces(StatusCodes.Status201Created)
+        .Produces(StatusCodes.Status400BadRequest);
     }
 }

--- a/Movies.VerticalSlice.Api/Middleware/ApiRequestLoggingMiddleware.cs
+++ b/Movies.VerticalSlice.Api/Middleware/ApiRequestLoggingMiddleware.cs
@@ -1,0 +1,314 @@
+using Movies.VerticalSlice.Api.Data.Database;
+using Movies.VerticalSlice.Api.Data.Models;
+using Movies.VerticalSlice.Api.Services;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+namespace Movies.VerticalSlice.Api.Middleware;
+
+public class ApiRequestLoggingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ApiRequestLoggingMiddleware> _logger;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+
+    public ApiRequestLoggingMiddleware(
+        RequestDelegate next, 
+        ILogger<ApiRequestLoggingMiddleware> logger,
+        IServiceScopeFactory serviceScopeFactory)
+    {
+        _next = next;
+        _logger = logger;
+        _serviceScopeFactory = serviceScopeFactory;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        // Skip logging for static files, health checks, and swagger
+        if (ShouldSkipLogging(context.Request.Path))
+        {
+            await _next(context);
+            return;
+        }
+
+        // Debug log to confirm middleware is running
+        _logger.LogInformation("ApiRequestLoggingMiddleware: Processing {Method} {Path}", 
+            context.Request.Method, context.Request.Path);
+
+        var stopwatch = Stopwatch.StartNew();
+        var originalBodyStream = context.Response.Body;
+
+        try
+        {
+            // Capture request details
+            var requestBody = await ReadRequestBodyAsync(context.Request);
+            
+            // Capture authenticated user info (from JWT token)
+            var userId = context.User.Identity?.IsAuthenticated == true 
+                ? context.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value 
+                : null;
+            var userName = context.User.Identity?.IsAuthenticated == true
+                ? context.User.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
+                : null;
+            
+            // Debug: Log what user info we captured
+            if (context.User.Identity?.IsAuthenticated == true)
+            {
+                _logger.LogInformation(
+                    "ApiRequestLoggingMiddleware: Authenticated user - UserId: {UserId}, UserName: {UserName}, IsAuthenticated: {IsAuthenticated}", 
+                    userId, userName, context.User.Identity.IsAuthenticated);
+                
+                // Log all claims for debugging
+                var allClaims = string.Join(", ", context.User.Claims.Select(c => $"{c.Type}={c.Value}"));
+                _logger.LogInformation("ApiRequestLoggingMiddleware: All claims: {Claims}", allClaims);
+            }
+            else
+            {
+                _logger.LogInformation("ApiRequestLoggingMiddleware: User is NOT authenticated");
+            }
+            
+            var requestPath = context.Request.Path.Value;
+            var method = context.Request.Method;
+            var queryString = context.Request.QueryString.Value;
+            
+            using var responseBody = new MemoryStream();
+            context.Response.Body = responseBody;
+
+            // Call the next middleware
+            await _next(context);
+
+            stopwatch.Stop();
+
+            // Capture response details
+            var responseBodyText = await ReadResponseBodyAsync(responseBody);
+            var statusCode = context.Response.StatusCode;
+            var duration = stopwatch.ElapsedMilliseconds;
+            
+            // Copy response back to original stream
+            responseBody.Seek(0, SeekOrigin.Begin);
+            await responseBody.CopyToAsync(originalBodyStream);
+
+            // Log to database asynchronously with a new scope
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    _logger.LogInformation("ApiRequestLoggingMiddleware: Starting database log for {Method} {Path}", 
+                        method, requestPath);
+                    
+                    using var scope = _serviceScopeFactory.CreateScope();
+                    var dbContext = scope.ServiceProvider.GetRequiredService<MoviesDbContext>();
+                    
+                    await LogRequestToDatabase(
+                        method,
+                        requestPath,
+                        queryString,
+                        userId,
+                        userName,
+                        requestBody,
+                        responseBodyText,
+                        statusCode,
+                        duration,
+                        dbContext);
+                    
+                    _logger.LogInformation("ApiRequestLoggingMiddleware: Successfully logged {Method} {Path} to database", 
+                        method, requestPath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to log API request to database for {Method} {Path}", method, requestPath);
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            
+            var userId = context.User.Identity?.IsAuthenticated == true 
+                ? context.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value 
+                : null;
+            var userName = context.User.Identity?.IsAuthenticated == true
+                ? context.User.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
+                : null;
+            var requestPath = context.Request.Path.Value;
+            var method = context.Request.Method;
+            var queryString = context.Request.QueryString.Value;
+            var duration = stopwatch.ElapsedMilliseconds;
+            
+            // Log error to database with a new scope
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    using var scope = _serviceScopeFactory.CreateScope();
+                    var dbContext = scope.ServiceProvider.GetRequiredService<MoviesDbContext>();
+                    
+                    await LogErrorToDatabase(
+                        method,
+                        requestPath,
+                        queryString,
+                        userId,
+                        userName,
+                        ex,
+                        duration,
+                        dbContext);
+                }
+                catch (Exception logEx)
+                {
+                    _logger.LogError(logEx, "Failed to log error to database");
+                }
+            });
+            
+            throw;
+        }
+        finally
+        {
+            context.Response.Body = originalBodyStream;
+        }
+    }
+
+    private bool ShouldSkipLogging(PathString path)
+    {
+        var pathValue = path.Value?.ToLower() ?? string.Empty;
+        
+        return pathValue.Contains("/swagger") ||
+               pathValue.Contains("/health") ||
+               pathValue.Contains("/_framework") ||
+               pathValue.Contains("/_vs") ||
+               pathValue.Contains(".css") ||
+               pathValue.Contains(".js") ||
+               pathValue.Contains(".map") ||
+               pathValue.Contains(".ico") ||
+               pathValue.Contains(".png") ||
+               pathValue.Contains(".jpg") ||
+               pathValue.Contains(".woff");
+    }
+
+    private async Task<string?> ReadRequestBodyAsync(HttpRequest request)
+    {
+        if (request.ContentLength == null || request.ContentLength == 0)
+            return null;
+
+        request.EnableBuffering();
+
+        try
+        {
+            using var reader = new StreamReader(
+                request.Body,
+                encoding: Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: false,
+                bufferSize: 1024,
+                leaveOpen: true);
+
+            var body = await reader.ReadToEndAsync();
+            request.Body.Position = 0;
+
+            // Truncate if too long
+            return body.Length > 4000 ? body.Substring(0, 4000) + "..." : body;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private async Task<string?> ReadResponseBodyAsync(MemoryStream responseBody)
+    {
+        try
+        {
+            responseBody.Seek(0, SeekOrigin.Begin);
+            var text = await new StreamReader(responseBody).ReadToEndAsync();
+            responseBody.Seek(0, SeekOrigin.Begin);
+
+            // Truncate if too long
+            return text.Length > 4000 ? text.Substring(0, 4000) + "..." : text;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private async Task LogRequestToDatabase(
+        string method,
+        string requestPath,
+        string queryString,
+        string? userId,
+        string? userName,
+        string? requestBody,
+        string? responseBody,
+        int statusCode,
+        long durationMs,
+        MoviesDbContext dbContext)
+    {
+        var properties = new
+        {
+            Method = method,
+            Path = requestPath,
+            QueryString = queryString,
+            StatusCode = statusCode,
+            Duration = $"{durationMs}ms",
+            UserId = userId,
+            UserName = userName,
+            RequestBody = requestBody,
+            ResponseBody = responseBody,
+            Headers = new Dictionary<string, string>()
+        };
+
+        var log = new ApplicationLog
+        {
+            Timestamp = DateTime.UtcNow,
+            Level = statusCode >= 500 ? "Error" :
+                    statusCode >= 400 ? "Warning" : "Information",
+            Category = "ApiRequest",
+            Message = $"{method} {requestPath} - {statusCode} ({durationMs}ms)" + 
+                      (userName != null ? $" - User: {userName}" : ""),
+            UserId = userId,
+            UserName = userName,
+            RequestPath = requestPath,
+            Properties = JsonSerializer.Serialize(properties)
+        };
+
+        dbContext.ApplicationLogs.Add(log);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private async Task LogErrorToDatabase(
+        string method,
+        string requestPath,
+        string queryString,
+        string? userId,
+        string? userName,
+        Exception exception,
+        long durationMs,
+        MoviesDbContext dbContext)
+    {
+        var properties = new
+        {
+            Method = method,
+            Path = requestPath,
+            QueryString = queryString,
+            Duration = $"{durationMs}ms",
+            UserId = userId,
+            UserName = userName
+        };
+
+        var log = new ApplicationLog
+        {
+            Timestamp = DateTime.UtcNow,
+            Level = "Error",
+            Category = "ApiRequest",
+            Message = $"{method} {requestPath} - Exception: {exception.Message}" + 
+                      (userName != null ? $" - User: {userName}" : ""),
+            Exception = exception.ToString(),
+            UserId = userId,
+            UserName = userName,
+            RequestPath = requestPath,
+            Properties = JsonSerializer.Serialize(properties)
+        };
+
+        dbContext.ApplicationLogs.Add(log);
+        await dbContext.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
Implemented custom middleware to log all API requests to the ApplicationLogs table, capturing method, path, status, user info, and more. Added authenticated GET /api/logs endpoint for querying logs with filters and pagination. Updated Swagger config to show padlocks only on protected endpoints. Improved endpoint metadata and documentation. Removed built-in HttpLogging middleware.