### PR TITLE
Expand MovieService tests & centralize endpoint URL logic

### DIFF
--- a/Movies.Api.VerticalSlice.Api.Tests/Service/MovieServiceTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Service/MovieServiceTests.cs
@@ -2,13 +2,18 @@
 using Moq;
 using Moq.Protected;
 using Movies.VerticalSlice.Api.Services;
+using Movies.VerticalSlice.Api.Shared.Constants;
+using Movies.VerticalSlice.Api.Shared.Dtos;
 using System.Net;
+using System.Text.Json;
 using Xunit;
-    
+     
 namespace Movies.Api.VerticalSlice.Api.Tests.Service;
 
 public class MovieServiceTests
 {
+    #region Delete Tests
+    
     [Fact]
     public async Task DeleteAsync_ReturnsUnauthorized_ThrowsException()
     {
@@ -23,7 +28,7 @@ public class MovieServiceTests
         var movieId = Given_we_have_a_movie_id();
         var (service, requestCapture) = And_we_have_a_service_with_request_capture();
         await When_we_delete_the_movie(service, movieId);
-        Then_correct_endpoint_should_be_called(requestCapture, movieId);
+        Then_correct_delete_endpoint_should_be_called(requestCapture, movieId);
     }
 
     [Fact]
@@ -35,10 +40,123 @@ public class MovieServiceTests
         Then_response_should_be_successful(response);
     }
 
+    #endregion
+
+    #region Update Tests
+
+    [Fact]
+    public async Task UpdateAsync_WithValidId_CallsCorrectEndpoint()
+    {
+        var movieId = Given_we_have_a_movie_id();
+        var movieDto = Given_we_have_a_movie_dto();
+        var (service, requestCapture) = And_we_have_a_service_with_request_capture();
+        await When_we_update_the_movie(service, movieId, movieDto);
+        Then_correct_update_endpoint_should_be_called(requestCapture, movieId);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsUnauthorized_ThrowsException()
+    {
+        var movieId = Given_we_have_a_movie_id();
+        var movieDto = Given_we_have_a_movie_dto();
+        var service = And_we_have_a_service_that_returns_unauthorized();
+        await Then_unauthorized_exception_should_be_thrown_on_update(service, movieId, movieDto);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsNoContent_CompletesSuccessfully()
+    {
+        var movieId = Given_we_have_a_movie_id();
+        var movieDto = Given_we_have_a_movie_dto();
+        var service = And_we_have_a_service_that_returns_no_content();
+        var response = await When_we_update_the_movie(service, movieId, movieDto);
+        Then_response_should_be_no_content(response);
+    }
+
+    #endregion
+
+    #region Create Tests
+
+    [Fact]
+    public async Task CreateAsync_WithValidMovie_CallsCorrectEndpoint()
+    {
+        var movieDto = Given_we_have_a_movie_dto();
+        var (service, requestCapture) = And_we_have_a_service_with_request_capture_created();
+        await When_we_create_the_movie(service, movieDto);
+        Then_correct_create_endpoint_should_be_called(requestCapture);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsUnauthorized_ThrowsException()
+    {
+        var movieDto = Given_we_have_a_movie_dto();
+        var service = And_we_have_a_service_that_returns_unauthorized();
+        await Then_unauthorized_exception_should_be_thrown_on_create(service, movieDto);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsCreated_CompletesSuccessfully()
+    {
+        var movieDto = Given_we_have_a_movie_dto();
+        var service = And_we_have_a_service_that_returns_created();
+        var response = await When_we_create_the_movie(service, movieDto);
+        Then_response_should_be_created(response);
+    }
+
+    #endregion
+
+    #region GetAll Tests
+
+    [Fact]
+    public async Task GetAllAsync_CallsCorrectEndpoint()
+    {
+        var (service, requestCapture) = And_we_have_a_service_with_request_capture_and_json_response();
+        await When_we_get_all_movies(service);
+        Then_correct_getall_endpoint_should_be_called(requestCapture);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsMovies_Successfully()
+    {
+        var expectedMovies = Given_we_have_a_list_of_movies();
+        var service = And_we_have_a_service_that_returns_movies(expectedMovies);
+        var movies = await When_we_get_all_movies(service);
+        Then_movies_should_be_returned(movies, expectedMovies);
+    }
+
+    #endregion
+
+    #region Given Methods
+
     Guid Given_we_have_a_movie_id()
     {
         return Guid.NewGuid();
     }
+
+    MovieDto Given_we_have_a_movie_dto()
+    {
+        return new MovieDto
+        {
+            MovieId = Guid.NewGuid(),
+            Title = "Test Movie",
+            YearOfRelease = 2024,
+            Slug = "test-movie",
+            Genres = "Action,Drama"
+        };
+    }
+
+    List<MovieDto> Given_we_have_a_list_of_movies()
+    {
+        return new List<MovieDto>
+        {
+            new MovieDto { MovieId = Guid.NewGuid(), Title = "Movie 1", Slug = "movie-1", YearOfRelease = 2023, Genres = "Action" },
+            new MovieDto { MovieId = Guid.NewGuid(), Title = "Movie 2", Slug = "movie-2", YearOfRelease = 2024, Genres = "Drama" }
+        };
+    }
+
+    #endregion
+
+    #region And Methods
 
     MovieService And_we_have_a_service_that_returns_unauthorized()
     {
@@ -65,11 +183,88 @@ public class MovieServiceTests
         return (service, requestCapture);
     }
 
+    (MovieService service, RequestCapture requestCapture) And_we_have_a_service_with_request_capture_created()
+    {
+        var requestCapture = new RequestCapture();
+        
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => requestCapture.CapturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created));
+
+        var service = CreateMovieService(handler);
+        
+        return (service, requestCapture);
+    }
+
+    (MovieService service, RequestCapture requestCapture) And_we_have_a_service_with_request_capture_and_json_response()
+    {
+        var requestCapture = new RequestCapture();
+        var movies = Given_we_have_a_list_of_movies();
+        var json = JsonSerializer.Serialize(movies);
+        
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => requestCapture.CapturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            });
+
+        var service = CreateMovieService(handler);
+        
+        return (service, requestCapture);
+    }
+
     MovieService And_we_have_a_service_that_returns_ok()
     {
         var handler = CreateMockHttpHandler(HttpStatusCode.OK);
         return CreateMovieService(handler);
     }
+
+    MovieService And_we_have_a_service_that_returns_no_content()
+    {
+        var handler = CreateMockHttpHandler(HttpStatusCode.NoContent);
+        return CreateMovieService(handler);
+    }
+
+    MovieService And_we_have_a_service_that_returns_created()
+    {
+        var handler = CreateMockHttpHandler(HttpStatusCode.Created);
+        return CreateMovieService(handler);
+    }
+
+    MovieService And_we_have_a_service_that_returns_movies(List<MovieDto> movies)
+    {
+        var json = JsonSerializer.Serialize(movies);
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            });
+        
+        return CreateMovieService(handler);
+    }
+
+    #endregion
+
+    #region When Methods
 
     async Task<HttpResponseMessage> When_we_delete_the_movie(
         MovieService service,
@@ -77,6 +272,30 @@ public class MovieServiceTests
     {
         return await service.DeleteAsync(movieId);
     }
+
+    async Task<HttpResponseMessage> When_we_update_the_movie(
+        MovieService service,
+        Guid movieId,
+        MovieDto movieDto)
+    {
+        return await service.UpdateAsync(movieId, movieDto);
+    }
+
+    async Task<HttpResponseMessage> When_we_create_the_movie(
+        MovieService service,
+        MovieDto movieDto)
+    {
+        return await service.CreateAsync(movieDto);
+    }
+
+    async Task<List<MovieDto>?> When_we_get_all_movies(MovieService service)
+    {
+        return await service.GetAllAsync();
+    }
+
+    #endregion
+
+    #region Then Methods
 
     async Task Then_unauthorized_exception_should_be_thrown(
         MovieService service,
@@ -86,7 +305,24 @@ public class MovieServiceTests
             () => service.DeleteAsync(movieId));
     }
 
-    void Then_correct_endpoint_should_be_called(
+    async Task Then_unauthorized_exception_should_be_thrown_on_update(
+        MovieService service,
+        Guid movieId,
+        MovieDto movieDto)
+    {
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => service.UpdateAsync(movieId, movieDto));
+    }
+
+    async Task Then_unauthorized_exception_should_be_thrown_on_create(
+        MovieService service,
+        MovieDto movieDto)
+    {
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => service.CreateAsync(movieDto));
+    }
+
+    void Then_correct_delete_endpoint_should_be_called(
         RequestCapture requestCapture,
         Guid movieId)
     {
@@ -95,13 +331,60 @@ public class MovieServiceTests
         requestCapture.CapturedRequest.RequestUri!.AbsolutePath.Should().Be($"/api/movies/{movieId}");
     }
 
+    void Then_correct_update_endpoint_should_be_called(
+        RequestCapture requestCapture,
+        Guid movieId)
+    {
+        requestCapture.CapturedRequest.Should().NotBeNull();
+        requestCapture.CapturedRequest!.Method.Should().Be(HttpMethod.Put);
+        requestCapture.CapturedRequest.RequestUri!.AbsolutePath.Should().Be("/api/movies");
+        requestCapture.CapturedRequest.RequestUri!.Query.Should().Be($"?id={movieId}");
+    }
+
+    void Then_correct_create_endpoint_should_be_called(RequestCapture requestCapture)
+    {
+        requestCapture.CapturedRequest.Should().NotBeNull();
+        requestCapture.CapturedRequest!.Method.Should().Be(HttpMethod.Post);
+        requestCapture.CapturedRequest.RequestUri!.AbsolutePath.Should().Be("/api/movies");
+    }
+
+    void Then_correct_getall_endpoint_should_be_called(RequestCapture requestCapture)
+    {
+        requestCapture.CapturedRequest.Should().NotBeNull();
+        requestCapture.CapturedRequest!.Method.Should().Be(HttpMethod.Get);
+        requestCapture.CapturedRequest.RequestUri!.AbsolutePath.Should().Be("/api/movies");
+    }
+
     void Then_response_should_be_successful(HttpResponseMessage response)
     {
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
-    // Helper methods to reduce duplication
+    void Then_response_should_be_no_content(HttpResponseMessage response)
+    {
+        response.Should().NotBeNull();
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    void Then_response_should_be_created(HttpResponseMessage response)
+    {
+        response.Should().NotBeNull();
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    void Then_movies_should_be_returned(List<MovieDto>? movies, List<MovieDto> expectedMovies)
+    {
+        movies.Should().NotBeNull();
+        movies.Should().HaveCount(expectedMovies.Count);
+        movies![0].Title.Should().Be(expectedMovies[0].Title);
+        movies[1].Title.Should().Be(expectedMovies[1].Title);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
     private Mock<HttpMessageHandler> CreateMockHttpHandler(HttpStatusCode statusCode)
     {
         var handler = new Mock<HttpMessageHandler>();
@@ -129,9 +412,10 @@ public class MovieServiceTests
         return new MovieService(factory.Object);
     }
 
-    // Helper class to capture the request by reference
     private class RequestCapture
     {
         public HttpRequestMessage? CapturedRequest { get; set; }
     }
+
+    #endregion
 }

--- a/Movies.VerticalSlice.Api.Services/Services/MovieService.cs
+++ b/Movies.VerticalSlice.Api.Services/Services/MovieService.cs
@@ -41,7 +41,7 @@ public class MovieService : IMovieService
           movieToUpdate.Genres
         );
 
-        var url = $"{ApiEndpoints.Movies.Update}?id={id}";
+        var url = ApiEndpoints.Movies.UpdateWithId(id);
         var response = await _httpClient.PutAsJsonAsync(url, updateRequest);
         CheckResponse(response);
         return response;
@@ -50,7 +50,7 @@ public class MovieService : IMovieService
 
     public async Task<HttpResponseMessage> DeleteAsync(Guid movieId)
     {
-        var url = $"/api/movies/{movieId}";
+        var url = ApiEndpoints.Movies.DeleteWithId(movieId);
         var response = await _httpClient.DeleteAsync(url);
 
         CheckResponse(response);

--- a/Movies.VerticalSlice.Api.Shared/Constants/ApiEndpoints.cs
+++ b/Movies.VerticalSlice.Api.Shared/Constants/ApiEndpoints.cs
@@ -6,14 +6,24 @@
         public static class Movies
         {
             public const string Base = $"{ApiBase}/movies";
-            public const string Create = Base; // or null
+            public const string Create = Base;
             public const string Get = "{idOrSlug}";
-            public const string GetAll = Base; // or null
+            public const string GetAll = Base;
             public const string Update = Base;
             public const string Delete = Base + "/{id}";
             public const string Rate = $"{Base}/{{movieId:guid}}/ratings";
             public const string DeleteRating = Rate;
             public const string Names = Base + "/names";
+
+            /// <summary>
+            /// Constructs the URL for updating a movie with query string parameter
+            /// </summary>
+            public static string UpdateWithId(Guid id) => $"{Update}?id={id}";
+
+            /// <summary>
+            /// Constructs the URL for deleting a movie by replacing the route parameter
+            /// </summary>
+            public static string DeleteWithId(Guid id) => $"{Base}/{id}";
         }
 
 
@@ -21,7 +31,7 @@
         {
             public const string Base = $"{ApiBase}/movies/ratings";
             public const string GetUserRatings = $"{Base}/me";
-            public const string GetAll = Base; // or n
+            public const string GetAll = Base;
         }
 
         public static class Users


### PR DESCRIPTION
Expanded MovieServiceTests to cover Create, Update, Delete, and GetAll methods with comprehensive scenarios and improved helper methods. Refactored MovieService to use new ApiEndpoints.Movies.UpdateWithId and DeleteWithId helpers for URL construction. Added these helpers to ApiEndpoints.cs to centralize and clarify endpoint logic. Improved maintainability and test coverage.