### PR TITLE
Refactor tests to BDD style with Given/When/Then helpers

### DIFF
--- a/Movies.Api.VerticalSlice.Api.Tests/Features/Logging/GetAllLogsEndpointTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Features/Logging/GetAllLogsEndpointTests.cs
@@ -20,160 +20,295 @@ public class GetAllLogsEndpointTests : IDisposable
         SeedTestData();
     }
 
+    #region Pagination Tests
+
     [Fact]
     public async Task GetLogs_WithValidPagination_ReturnsCorrectPage()
     {
-        // Arrange
-        var page = 1;
-        var pageSize = 2;
-
-        // Act
-        var logs = await _context.ApplicationLogs
-            .OrderByDescending(l => l.Timestamp)
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
-            .ToListAsync();
-
-        // Assert
-        logs.Should().HaveCount(2);
-        logs[0].Message.Should().Contain("Request 5"); // Most recent
-    }
-
-    [Fact]
-    public async Task GetLogs_FilterByLevel_ReturnsOnlyMatchingLogs()
-    {
-        // Arrange
-        var level = "Error";
-
-        // Act
-        var logs = await _context.ApplicationLogs
-            .Where(l => l.Level == level)
-            .ToListAsync();
-
-        // Assert
-        logs.Should().HaveCount(2);
-        logs.Should().AllSatisfy(l => l.Level.Should().Be("Error"));
-    }
-
-    [Fact]
-    public async Task GetLogs_FilterByCategory_ReturnsOnlyMatchingLogs()
-    {
-        // Arrange
-        var category = "ApiRequest";
-
-        // Act
-        var logs = await _context.ApplicationLogs
-            .Where(l => l.Category == category)
-            .ToListAsync();
-
-        // Assert
-        logs.Should().HaveCount(5);
-        logs.Should().AllSatisfy(l => l.Category.Should().Be("ApiRequest"));
-    }
-
-    [Fact]
-    public async Task GetLogs_FilterByStartDate_ReturnsOnlyLogsAfterDate()
-    {
-        // Arrange
-        var startDate = DateTime.UtcNow.AddMinutes(-3);
-
-        // Act
-        var logs = await _context.ApplicationLogs
-            .Where(l => l.Timestamp >= startDate)
-            .ToListAsync();
-
-        // Assert
-        logs.Count.Should().BeGreaterThanOrEqualTo(2);
-    }
-
-    [Fact]
-    public async Task GetLogs_FilterByEndDate_ReturnsOnlyLogsBeforeDate()
-    {
-        // Arrange
-        var endDate = DateTime.UtcNow.AddMinutes(-3);
-
-        // Act
-        var logs = await _context.ApplicationLogs
-            .Where(l => l.Timestamp <= endDate)
-            .ToListAsync();
-
-        // Assert
-        logs.Count.Should().BeGreaterThanOrEqualTo(3);
-    }
-
-    [Fact]
-    public async Task GetLogs_CombinedFilters_ReturnsCorrectSubset()
-    {
-        // Arrange
-        var level = "Information";
-        var category = "ApiRequest";
-
-        // Act
-        var logs = await _context.ApplicationLogs
-            .Where(l => l.Level == level && l.Category == category)
-            .ToListAsync();
-
-        // Assert
-        logs.Should().HaveCount(2);
-        logs.Should().AllSatisfy(l =>
-        {
-            l.Level.Should().Be("Information");
-            l.Category.Should().Be("ApiRequest");
-        });
-    }
-
-    [Fact]
-    public void PageValidation_NegativePage_IsCorrectedToOne()
-    {
-        // Arrange
-        var page = -1;
-
-        // Act
-        var correctedPage = Math.Max(page, 1);
-
-        // Assert
-        correctedPage.Should().Be(1);
-    }
-
-    [Fact]
-    public void PageSizeValidation_TooLarge_IsClampedTo100()
-    {
-        // Arrange
-        var pageSize = 1000;
-
-        // Act
-        var correctedPageSize = Math.Clamp(pageSize, 1, 100);
-
-        // Assert
-        correctedPageSize.Should().Be(100);
-    }
-
-    [Fact]
-    public void PageSizeValidation_Zero_IsCorrectedToOne()
-    {
-        // Arrange
-        var pageSize = 0;
-
-        // Act
-        var correctedPageSize = Math.Clamp(pageSize, 1, 100);
-
-        // Assert
-        correctedPageSize.Should().Be(1);
+        Given_we_have_seeded_test_data();
+        var (page, pageSize) = And_we_have_pagination_parameters(1, 2);
+        var logs = await When_we_get_logs_with_pagination(page, pageSize);
+        Then_logs_should_have_count(logs, 2);
+        And_most_recent_log_should_be_first(logs);
     }
 
     [Fact]
     public async Task GetLogs_Pagination_CalculatesTotalPagesCorrectly()
     {
-        // Arrange
-        var totalCount = await _context.ApplicationLogs.CountAsync();
-        var pageSize = 2;
-
-        // Act
-        var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
-
-        // Assert
-        totalPages.Should().Be(3); // 5 logs / 2 per page = 3 pages
+        Given_we_have_seeded_test_data();
+        var totalCount = await When_we_count_total_logs();
+        var pageSize = And_we_have_page_size(2);
+        var totalPages = When_we_calculate_total_pages(totalCount, pageSize);
+        Then_total_pages_should_be(totalPages, 3);
     }
+
+    #endregion
+
+    #region Filter Tests
+
+    [Fact]
+    public async Task GetLogs_FilterByLevel_ReturnsOnlyMatchingLogs()
+    {
+        Given_we_have_seeded_test_data();
+        var level = And_we_have_error_level_filter();
+        var logs = await When_we_filter_logs_by_level(level);
+        Then_logs_should_have_count(logs, 2);
+        And_all_logs_should_have_level(logs, level);
+    }
+
+    [Fact]
+    public async Task GetLogs_FilterByCategory_ReturnsOnlyMatchingLogs()
+    {
+        Given_we_have_seeded_test_data();
+        var category = And_we_have_api_request_category_filter();
+        var logs = await When_we_filter_logs_by_category(category);
+        Then_logs_should_have_count(logs, 5);
+        And_all_logs_should_have_category(logs, category);
+    }
+
+    [Fact]
+    public async Task GetLogs_FilterByStartDate_ReturnsOnlyLogsAfterDate()
+    {
+        Given_we_have_seeded_test_data();
+        var startDate = And_we_have_start_date_filter();
+        var logs = await When_we_filter_logs_by_start_date(startDate);
+        Then_logs_count_should_be_at_least(logs, 2);
+    }
+
+    [Fact]
+    public async Task GetLogs_FilterByEndDate_ReturnsOnlyLogsBeforeDate()
+    {
+        Given_we_have_seeded_test_data();
+        var endDate = And_we_have_end_date_filter();
+        var logs = await When_we_filter_logs_by_end_date(endDate);
+        Then_logs_count_should_be_at_least(logs, 3);
+    }
+
+    [Fact]
+    public async Task GetLogs_CombinedFilters_ReturnsCorrectSubset()
+    {
+        Given_we_have_seeded_test_data();
+        var (level, category) = And_we_have_combined_filters();
+        var logs = await When_we_filter_logs_by_level_and_category(level, category);
+        Then_logs_should_have_count(logs, 2);
+        And_all_logs_should_match_filters(logs, level, category);
+    }
+
+    #endregion
+
+    #region Validation Tests
+
+    [Fact]
+    public void PageValidation_NegativePage_IsCorrectedToOne()
+    {
+        var page = Given_we_have_negative_page();
+        var correctedPage = When_we_validate_page_number(page);
+        Then_page_should_be(correctedPage, 1);
+    }
+
+    [Fact]
+    public void PageSizeValidation_TooLarge_IsClampedTo100()
+    {
+        var pageSize = Given_we_have_oversized_page_size();
+        var correctedPageSize = When_we_validate_page_size(pageSize);
+        Then_page_size_should_be(correctedPageSize, 100);
+    }
+
+    [Fact]
+    public void PageSizeValidation_Zero_IsCorrectedToOne()
+    {
+        var pageSize = Given_we_have_zero_page_size();
+        var correctedPageSize = When_we_validate_page_size(pageSize);
+        Then_page_size_should_be(correctedPageSize, 1);
+    }
+
+    #endregion
+
+    #region Given Methods
+
+    void Given_we_have_seeded_test_data()
+    {
+        // Data already seeded in constructor
+    }
+
+    int Given_we_have_negative_page()
+    {
+        return -1;
+    }
+
+    int Given_we_have_oversized_page_size()
+    {
+        return 1000;
+    }
+
+    int Given_we_have_zero_page_size()
+    {
+        return 0;
+    }
+
+    #endregion
+
+    #region And Methods
+
+    (int page, int pageSize) And_we_have_pagination_parameters(int page, int pageSize)
+    {
+        return (page, pageSize);
+    }
+
+    int And_we_have_page_size(int pageSize)
+    {
+        return pageSize;
+    }
+
+    string And_we_have_error_level_filter()
+    {
+        return "Error";
+    }
+
+    string And_we_have_api_request_category_filter()
+    {
+        return "ApiRequest";
+    }
+
+    DateTime And_we_have_start_date_filter()
+    {
+        return DateTime.UtcNow.AddMinutes(-3);
+    }
+
+    DateTime And_we_have_end_date_filter()
+    {
+        return DateTime.UtcNow.AddMinutes(-3);
+    }
+
+    (string level, string category) And_we_have_combined_filters()
+    {
+        return ("Information", "ApiRequest");
+    }
+
+    void And_most_recent_log_should_be_first(List<ApplicationLog> logs)
+    {
+        logs[0].Message.Should().Contain("Request 5");
+    }
+
+    void And_all_logs_should_have_level(List<ApplicationLog> logs, string level)
+    {
+        logs.Should().AllSatisfy(l => l.Level.Should().Be(level));
+    }
+
+    void And_all_logs_should_have_category(List<ApplicationLog> logs, string category)
+    {
+        logs.Should().AllSatisfy(l => l.Category.Should().Be(category));
+    }
+
+    void And_all_logs_should_match_filters(List<ApplicationLog> logs, string level, string category)
+    {
+        logs.Should().AllSatisfy(l =>
+        {
+            l.Level.Should().Be(level);
+            l.Category.Should().Be(category);
+        });
+    }
+
+    #endregion
+
+    #region When Methods
+
+    async Task<List<ApplicationLog>> When_we_get_logs_with_pagination(int page, int pageSize)
+    {
+        return await _context.ApplicationLogs
+            .OrderByDescending(l => l.Timestamp)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+    }
+
+    async Task<int> When_we_count_total_logs()
+    {
+        return await _context.ApplicationLogs.CountAsync();
+    }
+
+    int When_we_calculate_total_pages(int totalCount, int pageSize)
+    {
+        return (int)Math.Ceiling(totalCount / (double)pageSize);
+    }
+
+    async Task<List<ApplicationLog>> When_we_filter_logs_by_level(string level)
+    {
+        return await _context.ApplicationLogs
+            .Where(l => l.Level == level)
+            .ToListAsync();
+    }
+
+    async Task<List<ApplicationLog>> When_we_filter_logs_by_category(string category)
+    {
+        return await _context.ApplicationLogs
+            .Where(l => l.Category == category)
+            .ToListAsync();
+    }
+
+    async Task<List<ApplicationLog>> When_we_filter_logs_by_start_date(DateTime startDate)
+    {
+        return await _context.ApplicationLogs
+            .Where(l => l.Timestamp >= startDate)
+            .ToListAsync();
+    }
+
+    async Task<List<ApplicationLog>> When_we_filter_logs_by_end_date(DateTime endDate)
+    {
+        return await _context.ApplicationLogs
+            .Where(l => l.Timestamp <= endDate)
+            .ToListAsync();
+    }
+
+    async Task<List<ApplicationLog>> When_we_filter_logs_by_level_and_category(string level, string category)
+    {
+        return await _context.ApplicationLogs
+            .Where(l => l.Level == level && l.Category == category)
+            .ToListAsync();
+    }
+
+    int When_we_validate_page_number(int page)
+    {
+        return Math.Max(page, 1);
+    }
+
+    int When_we_validate_page_size(int pageSize)
+    {
+        return Math.Clamp(pageSize, 1, 100);
+    }
+
+    #endregion
+
+    #region Then Methods
+
+    void Then_logs_should_have_count(List<ApplicationLog> logs, int expectedCount)
+    {
+        logs.Should().HaveCount(expectedCount);
+    }
+
+    void Then_logs_count_should_be_at_least(List<ApplicationLog> logs, int minimumCount)
+    {
+        logs.Count.Should().BeGreaterThanOrEqualTo(minimumCount);
+    }
+
+    void Then_total_pages_should_be(int totalPages, int expected)
+    {
+        totalPages.Should().Be(expected);
+    }
+
+    void Then_page_should_be(int page, int expected)
+    {
+        page.Should().Be(expected);
+    }
+
+    void Then_page_size_should_be(int pageSize, int expected)
+    {
+        pageSize.Should().Be(expected);
+    }
+
+    #endregion
+
+    #region Helper Methods
 
     private void SeedTestData()
     {
@@ -229,6 +364,8 @@ public class GetAllLogsEndpointTests : IDisposable
         _context.ApplicationLogs.AddRange(logs);
         _context.SaveChanges();
     }
+
+    #endregion
 
     public void Dispose()
     {

--- a/Movies.Api.VerticalSlice.Api.Tests/Middleware/ApiRequestLoggingMiddlewareTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Middleware/ApiRequestLoggingMiddlewareTests.cs
@@ -9,165 +9,231 @@ namespace Movies.Api.VerticalSlice.Api.Tests.Middleware;
 
 public class ApiRequestLoggingMiddlewareTests
 {
+    #region ShouldSkipLogging Tests
+
     [Fact]
     public void ShouldSkipLogging_SwaggerPath_ReturnsTrue()
     {
-        // Arrange
-        var middleware = CreateMiddleware();
-        var path = new PathString("/swagger/index.html");
-
-        // Act
-        var result = InvokeShouldSkipLogging(middleware, path);
-
-        // Assert
-        result.Should().BeTrue();
+        var middleware = Given_we_have_middleware();
+        var path = And_we_have_swagger_path();
+        var result = When_we_check_should_skip_logging(middleware, path);
+        Then_result_should_be_true(result);
     }
 
     [Fact]
     public void ShouldSkipLogging_ApiLogsPath_ReturnsTrue()
     {
-        // Arrange
-        var middleware = CreateMiddleware();
-        var path = new PathString("/api/logs");
-
-        // Act
-        var result = InvokeShouldSkipLogging(middleware, path);
-
-        // Assert
-        result.Should().BeTrue();
+        var middleware = Given_we_have_middleware();
+        var path = And_we_have_api_logs_path();
+        var result = When_we_check_should_skip_logging(middleware, path);
+        Then_result_should_be_true(result);
     }
 
     [Fact]
     public void ShouldSkipLogging_RegularApiPath_ReturnsFalse()
     {
-        // Arrange
-        var middleware = CreateMiddleware();
-        var path = new PathString("/api/movies");
-
-        // Act
-        var result = InvokeShouldSkipLogging(middleware, path);
-
-        // Assert
-        result.Should().BeFalse();
+        var middleware = Given_we_have_middleware();
+        var path = And_we_have_regular_api_path();
+        var result = When_we_check_should_skip_logging(middleware, path);
+        Then_result_should_be_false(result);
     }
+
+    #endregion
+
+    #region ShouldSkipBodyLogging Tests
 
     [Fact]
     public void ShouldSkipBodyLogging_LoginPath_ReturnsTrue()
     {
-        // Arrange
-        var middleware = CreateMiddleware();
-        var path = new PathString("/api/users/login");
-
-        // Act
-        var result = InvokeShouldSkipBodyLogging(middleware, path);
-
-        // Assert
-        result.Should().BeTrue();
+        var middleware = Given_we_have_middleware();
+        var path = And_we_have_login_path();
+        var result = When_we_check_should_skip_body_logging(middleware, path);
+        Then_result_should_be_true(result);
     }
 
     [Fact]
     public void ShouldSkipBodyLogging_RegisterPath_ReturnsTrue()
     {
-        // Arrange
-        var middleware = CreateMiddleware();
-        var path = new PathString("/api/users/register");
-
-        // Act
-        var result = InvokeShouldSkipBodyLogging(middleware, path);
-
-        // Assert
-        result.Should().BeTrue();
+        var middleware = Given_we_have_middleware();
+        var path = And_we_have_register_path();
+        var result = When_we_check_should_skip_body_logging(middleware, path);
+        Then_result_should_be_true(result);
     }
+
+    #endregion
+
+    #region RedactSensitiveData Tests
 
     [Fact]
     public void RedactSensitiveData_PasswordField_IsRedacted()
     {
-        // Arrange
-        var middleware = CreateMiddleware();
-        var body = "{\"username\":\"test\",\"password\":\"secret123\"}";
-        var path = new PathString("/api/test");
-
-        // Act
-        var result = InvokeRedactSensitiveData(middleware, body, path);
-
-        // Assert
-        result.Should().Contain("\"password\":\"[REDACTED]\"");
-        result.Should().Contain("\"username\":\"test\"");
+        var middleware = Given_we_have_middleware();
+        var body = And_we_have_body_with_password();
+        var path = And_we_have_test_path();
+        var result = When_we_redact_sensitive_data(middleware, body, path);
+        Then_password_should_be_redacted(result);
+        And_username_should_remain_visible(result);
     }
 
     [Fact]
     public void RedactSensitiveData_AuthenticationEndpoint_ReturnsRedactedPlaceholder()
     {
-        // Arrange
-        var middleware = CreateMiddleware();
-        var body = "{\"username\":\"test\",\"password\":\"secret123\"}";
-        var path = new PathString("/api/users/login");
-
-        // Act
-        var result = InvokeRedactSensitiveData(middleware, body, path);
-
-        // Assert
-        result.Should().Be("[REDACTED - Sensitive Authentication Data]");
+        var middleware = Given_we_have_middleware();
+        var body = And_we_have_authentication_body();
+        var path = And_we_have_login_path();
+        var result = When_we_redact_sensitive_data(middleware, body, path);
+        Then_result_should_be_authentication_placeholder(result);
     }
 
     [Fact]
     public void RedactSensitiveData_TokenField_IsRedacted()
     {
-        // Arrange
-        var middleware = CreateMiddleware();
-        var body = "{\"username\":\"test\",\"token\":\"abc123xyz\"}";
-        var path = new PathString("/api/test");
-
-        // Act
-        var result = InvokeRedactSensitiveData(middleware, body, path);
-
-        // Assert
-        result.Should().Contain("\"token\":\"[REDACTED]\"");
+        var middleware = Given_we_have_middleware();
+        var body = And_we_have_body_with_token();
+        var path = And_we_have_test_path();
+        var result = When_we_redact_sensitive_data(middleware, body, path);
+        Then_token_should_be_redacted(result);
     }
 
     [Fact]
     public void RedactSensitiveData_NonJsonBody_ReturnsOriginal()
     {
-        // Arrange
-        var middleware = CreateMiddleware();
-        var body = "This is not JSON";
-        var path = new PathString("/api/test");
-
-        // Act
-        var result = InvokeRedactSensitiveData(middleware, body, path);
-
-        // Assert
-        result.Should().Be(body);
+        var middleware = Given_we_have_middleware();
+        var body = And_we_have_non_json_body();
+        var path = And_we_have_test_path();
+        var result = When_we_redact_sensitive_data(middleware, body, path);
+        Then_result_should_be_original(result, body);
     }
 
-    private ApiRequestLoggingMiddleware CreateMiddleware()
+    #endregion
+
+    #region Given Methods
+
+    ApiRequestLoggingMiddleware Given_we_have_middleware()
     {
         var next = new RequestDelegate(_ => Task.CompletedTask);
         var logger = new Mock<ILogger<ApiRequestLoggingMiddleware>>();
         var serviceScopeFactory = new Mock<IServiceScopeFactory>();
-
         return new ApiRequestLoggingMiddleware(next, logger.Object, serviceScopeFactory.Object);
     }
 
-    // Helper methods to invoke private methods via reflection
-    private bool InvokeShouldSkipLogging(ApiRequestLoggingMiddleware middleware, PathString path)
+    #endregion
+
+    #region And Methods
+
+    PathString And_we_have_swagger_path()
+    {
+        return new PathString("/swagger/index.html");
+    }
+
+    PathString And_we_have_api_logs_path()
+    {
+        return new PathString("/api/logs");
+    }
+
+    PathString And_we_have_regular_api_path()
+    {
+        return new PathString("/api/movies");
+    }
+
+    PathString And_we_have_login_path()
+    {
+        return new PathString("/api/users/login");
+    }
+
+    PathString And_we_have_register_path()
+    {
+        return new PathString("/api/users/register");
+    }
+
+    PathString And_we_have_test_path()
+    {
+        return new PathString("/api/test");
+    }
+
+    string And_we_have_body_with_password()
+    {
+        return "{\"username\":\"test\",\"password\":\"secret123\"}";
+    }
+
+    string And_we_have_authentication_body()
+    {
+        return "{\"username\":\"test\",\"password\":\"secret123\"}";
+    }
+
+    string And_we_have_body_with_token()
+    {
+        return "{\"username\":\"test\",\"token\":\"abc123xyz\"}";
+    }
+
+    string And_we_have_non_json_body()
+    {
+        return "This is not JSON";
+    }
+
+    void And_username_should_remain_visible(string result)
+    {
+        result.Should().Contain("\"username\":\"test\"");
+    }
+
+    #endregion
+
+    #region When Methods
+
+    bool When_we_check_should_skip_logging(ApiRequestLoggingMiddleware middleware, PathString path)
     {
         var method = typeof(ApiRequestLoggingMiddleware)
             .GetMethod("ShouldSkipLogging", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         return (bool)method!.Invoke(middleware, new object[] { path })!;
     }
 
-    private bool InvokeShouldSkipBodyLogging(ApiRequestLoggingMiddleware middleware, PathString path)
+    bool When_we_check_should_skip_body_logging(ApiRequestLoggingMiddleware middleware, PathString path)
     {
         var method = typeof(ApiRequestLoggingMiddleware)
             .GetMethod("ShouldSkipBodyLogging", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         return (bool)method!.Invoke(middleware, new object[] { path })!;
     }
 
-    private string? InvokeRedactSensitiveData(ApiRequestLoggingMiddleware middleware, string? body, PathString path)
+    string? When_we_redact_sensitive_data(ApiRequestLoggingMiddleware middleware, string? body, PathString path)
     {
         var method = typeof(ApiRequestLoggingMiddleware)
             .GetMethod("RedactSensitiveData", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         return (string?)method!.Invoke(middleware, new object?[] { body, path });
     }
+
+    #endregion
+
+    #region Then Methods
+
+    void Then_result_should_be_true(bool result)
+    {
+        result.Should().BeTrue();
+    }
+
+    void Then_result_should_be_false(bool result)
+    {
+        result.Should().BeFalse();
+    }
+
+    void Then_password_should_be_redacted(string result)
+    {
+        result.Should().Contain("\"password\":\"[REDACTED]\"");
+    }
+
+    void Then_result_should_be_authentication_placeholder(string result)
+    {
+        result.Should().Be("[REDACTED - Sensitive Authentication Data]");
+    }
+
+    void Then_token_should_be_redacted(string result)
+    {
+        result.Should().Contain("\"token\":\"[REDACTED]\"");
+    }
+
+    void Then_result_should_be_original(string result, string expected)
+    {
+        result.Should().Be(expected);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Refactored GetAllLogsEndpointTests and ApiRequestLoggingMiddlewareTests to use a structured BDD approach. Tests are now organized into regions and use descriptive Given/And/When/Then helper methods for setup, action, and assertions. This improves readability, maintainability, and clarity of test intent. No changes to application logic.