### PR TITLE
Add unit tests for movie handlers and ratings service

### DIFF
--- a/Movies.Api.VerticalSlice.Api.Tests/Handlers/CreateMovieHandlerTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Handlers/CreateMovieHandlerTests.cs
@@ -1,0 +1,163 @@
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Movies.VerticalSlice.Api.Data.Database;
+using Movies.VerticalSlice.Api.Data.Models;
+using Movies.VerticalSlice.Api.Features.Movies.Create;
+using Xunit;
+
+namespace Movies.Api.VerticalSlice.Api.Tests.Handlers;
+
+public class CreateMovieHandlerTests
+{
+    [Fact]
+    public async Task Handle_ValidCommand_CreatesMovieSuccessfully()
+    {
+        var command = Given_we_have_a_valid_create_command();
+        var (handler, context) = And_we_have_a_handler();
+        var result = await When_we_handle_the_command(handler, command);
+        Then_a_movie_should_be_created(result, context, command);
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_ReturnsNewMovieId()
+    {
+        var command = Given_we_have_a_valid_create_command();
+        var (handler, _) = And_we_have_a_handler();
+        var result = await When_we_handle_the_command(handler, command);
+        Then_the_movie_id_should_be_valid(result);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidCommand_ThrowsValidationException()
+    {
+        var command = Given_we_have_an_invalid_create_command();
+        var (handler, _) = And_we_have_a_handler();
+        await Then_validation_exception_should_be_thrown(handler, command);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateMovie_ThrowsValidationException()
+    {
+        var command = Given_we_have_a_valid_create_command();
+        var (handler, context) = And_we_have_a_handler_with_existing_movie();
+        await Then_validation_exception_should_be_thrown(handler, command);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidYearOfRelease_ThrowsValidationException()
+    {
+        var command = Given_we_have_a_command_with_invalid_year();
+        var (handler, _) = And_we_have_a_handler();
+        await Then_validation_exception_should_be_thrown(handler, command);
+    }
+
+    CreateMovieCommand Given_we_have_a_valid_create_command()
+    {
+        return new CreateMovieCommand(
+            Title: "Test Movie",
+            YearOfRelease: 2024,
+            Genres: "Action,Drama",
+            UserId: "user-123");
+    }
+
+    CreateMovieCommand Given_we_have_an_invalid_create_command()
+    {
+        return new CreateMovieCommand(
+            Title: "",
+            YearOfRelease: 2024,
+            Genres: "Action",
+            UserId: "user-123");
+    }
+
+    CreateMovieCommand Given_we_have_a_command_with_invalid_year()
+    {
+        return new CreateMovieCommand(
+            Title: "Future Movie",
+            YearOfRelease: 1800,
+            Genres: "Action",
+            UserId: "user-123");
+    }
+
+    (CreateMovieHandler handler, MoviesDbContext context) And_we_have_a_handler()
+    {
+        var context = CreateTestContext();
+        var handler = CreateHandler(context);
+        return (handler, context);
+    }
+
+    (CreateMovieHandler handler, MoviesDbContext context) And_we_have_a_handler_with_existing_movie()
+    {
+        var context = CreateTestContext();
+
+        var existingMovie = new Movie
+        {
+            MovieId = Guid.NewGuid(),
+            Title = "Test Movie",
+            YearOfRelease = 2024,
+            Genres = "Action,Drama",
+            UserId = "user-123",
+            DateUpdated = DateTime.UtcNow
+        };
+
+        context.Movies.Add(existingMovie);
+        context.SaveChanges();
+
+        var handler = CreateHandler(context);
+        return (handler, context);
+    }
+
+    async Task<Guid> When_we_handle_the_command(
+        CreateMovieHandler handler,
+        CreateMovieCommand command)
+    {
+        return await handler.Handle(command, CancellationToken.None);
+    }
+
+    void Then_a_movie_should_be_created(
+        Guid result,
+        MoviesDbContext context,
+        CreateMovieCommand command)
+    {
+        result.Should().NotBeEmpty();
+
+        var createdMovie = context.Movies.FirstOrDefault(m => m.MovieId == result);
+        createdMovie.Should().NotBeNull();
+        createdMovie!.Title.Should().Be(command.Title);
+        createdMovie.YearOfRelease.Should().Be(command.YearOfRelease);
+        createdMovie.Genres.Should().Be(command.Genres);
+        createdMovie.UserId.Should().Be(command.UserId);
+    }
+
+    void Then_the_movie_id_should_be_valid(Guid result)
+    {
+        result.Should().NotBeEmpty();
+    }
+
+    async Task Then_validation_exception_should_be_thrown(
+        CreateMovieHandler handler,
+        CreateMovieCommand command)
+    {
+        await Assert.ThrowsAsync<ValidationException>(
+            () => handler.Handle(command, CancellationToken.None));
+    }
+
+    // Helper methods to reduce duplication
+    private MoviesDbContext CreateTestContext()
+    {
+        var options = new DbContextOptionsBuilder<MoviesDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new MoviesDbContext(options);
+    }
+
+    private CreateMovieHandler CreateHandler(MoviesDbContext context)
+    {
+        var validator = new CreateMovieValidator(context);
+        var mockLogger = new Mock<ILogger<CreateMovieHandler>>();
+        return new CreateMovieHandler(context, validator, mockLogger.Object);
+    }
+}

--- a/Movies.Api.VerticalSlice.Api.Tests/Handlers/DeleteMovieHandlerTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Handlers/DeleteMovieHandlerTests.cs
@@ -1,0 +1,118 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Movies.VerticalSlice.Api.Data.Database;
+using Movies.VerticalSlice.Api.Data.Models;
+using Movies.VerticalSlice.Api.Features.Movies.Delete;
+using Xunit;
+
+namespace Movies.Api.VerticalSlice.Api.Tests.Handlers;
+
+public class DeleteMovieHandlerTests
+{
+    [Fact]
+    public async Task Handle_ValidCommand_DeletesMovieSuccessfully()
+    {
+        var command = Given_we_have_a_valid_delete_command();
+        var (handler, context) = And_we_have_a_handler_with_existing_movie(command.MovieId);
+        var result = await When_we_handle_the_command(handler, command);
+        Then_a_movie_should_be_deleted(result, context, command.MovieId);
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_ReturnsTrue()
+    {
+        var command = Given_we_have_a_valid_delete_command();
+        var (handler, _) = And_we_have_a_handler_with_existing_movie(command.MovieId);
+        var result = await When_we_handle_the_command(handler, command);
+        Then_the_result_should_be_true(result);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentMovie_ReturnsFalse()
+    {
+        var command = Given_we_have_a_valid_delete_command();
+        var (handler, _) = And_we_have_a_handler_without_movie();
+        var result = await When_we_handle_the_command(handler, command);
+        Then_the_result_should_be_false(result);
+    }
+
+    DeleteMovieCommand Given_we_have_a_valid_delete_command()
+    {
+        return new DeleteMovieCommand(
+            MovieId: Guid.Parse("11111111-1111-1111-1111-111111111111"));
+    }
+
+    (DeleteMovieHandler handler, MoviesDbContext context) And_we_have_a_handler_with_existing_movie(Guid movieId)
+    {
+        var context = CreateTestContext();
+
+        var movie = new Movie
+        {
+            MovieId = movieId,
+            Title = "Test Movie",
+            YearOfRelease = 2023,
+            Genres = "Action",
+            UserId = "user-123",
+            DateUpdated = DateTime.UtcNow
+        };
+
+        context.Movies.Add(movie);
+        context.SaveChanges();
+
+        var handler = CreateHandler(context);
+        return (handler, context);
+    }
+
+    (DeleteMovieHandler handler, MoviesDbContext context) And_we_have_a_handler_without_movie()
+    {
+        var context = CreateTestContext();
+        var handler = CreateHandler(context);
+        return (handler, context);
+    }
+
+    async Task<bool> When_we_handle_the_command(
+        DeleteMovieHandler handler,
+        DeleteMovieCommand command)
+    {
+        return await handler.Handle(command, CancellationToken.None);
+    }
+
+    void Then_a_movie_should_be_deleted(
+        bool result,
+        MoviesDbContext context,
+        Guid movieId)
+    {
+        result.Should().BeTrue();
+
+        var deletedMovie = context.Movies.FirstOrDefault(m => m.MovieId == movieId);
+        deletedMovie.Should().BeNull();
+    }
+
+    void Then_the_result_should_be_true(bool result)
+    {
+        result.Should().BeTrue();
+    }
+
+    void Then_the_result_should_be_false(bool result)
+    {
+        result.Should().BeFalse();
+    }
+
+    // Helper methods to reduce duplication
+    private MoviesDbContext CreateTestContext()
+    {
+        var options = new DbContextOptionsBuilder<MoviesDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new MoviesDbContext(options);
+    }
+
+    private DeleteMovieHandler CreateHandler(MoviesDbContext context)
+    {
+        var mockLogger = new Mock<ILogger<DeleteMovieHandler>>();
+        return new DeleteMovieHandler(context, mockLogger.Object);
+    }
+}

--- a/Movies.Api.VerticalSlice.Api.Tests/Handlers/UpdateMovieHandlerTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Handlers/UpdateMovieHandlerTests.cs
@@ -1,0 +1,166 @@
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Movies.VerticalSlice.Api.Data.Database;
+using Movies.VerticalSlice.Api.Data.Models;
+using Movies.VerticalSlice.Api.Features.Movies.Update;
+using Xunit;
+
+namespace Movies.Api.VerticalSlice.Api.Tests.Handlers;
+
+public class UpdateMovieHandlerTests
+{
+    [Fact]
+    public async Task Handle_ValidCommand_UpdatesMovieSuccessfully()
+    {
+        var command = Given_we_have_a_valid_update_command();
+        var (handler, context) = And_we_have_a_handler_with_existing_movie(command.MovieId);
+        var result = await When_we_handle_the_command(handler, command);
+        Then_a_movie_should_be_updated(result, context, command);
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_ReturnsTrue()
+    {
+        var command = Given_we_have_a_valid_update_command();
+        var (handler, _) = And_we_have_a_handler_with_existing_movie(command.MovieId);
+        var result = await When_we_handle_the_command(handler, command);
+        Then_the_result_should_be_true(result);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentMovie_ReturnsFalse()
+    {
+        var command = Given_we_have_a_valid_update_command();
+        var (handler, _) = And_we_have_a_handler_without_movie();
+        await Then_validation_exception_should_be_thrown(handler, command);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidCommand_ThrowsValidationException()
+    {
+        var command = Given_we_have_an_invalid_update_command();
+        var (handler, _) = And_we_have_a_handler_without_movie();
+        await Then_validation_exception_should_be_thrown(handler, command);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidYearOfRelease_ThrowsValidationException()
+    {
+        var command = Given_we_have_a_command_with_invalid_year();
+        var (handler, _) = And_we_have_a_handler_with_existing_movie(command.MovieId);
+        await Then_validation_exception_should_be_thrown(handler, command);
+    }
+
+    UpdateMovieCommand Given_we_have_a_valid_update_command()
+    {
+        return new UpdateMovieCommand(
+            MovieId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Title: "Updated Movie",
+            YearOfRelease: 2024,
+            Genres: "Action,Drama",
+            UserId: "user-123");
+    }
+
+    UpdateMovieCommand Given_we_have_an_invalid_update_command()
+    {
+        return new UpdateMovieCommand(
+            MovieId: Guid.Empty,
+            Title: "",
+            YearOfRelease: 2024,
+            Genres: "Action",
+            UserId: "user-123");
+    }
+
+    UpdateMovieCommand Given_we_have_a_command_with_invalid_year()
+    {
+        return new UpdateMovieCommand(
+            MovieId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Title: "Updated Movie",
+            YearOfRelease: 1700,
+            Genres: "Action",
+            UserId: "user-123");
+    }
+
+    (UpdateMovieHandler handler, MoviesDbContext context) And_we_have_a_handler_with_existing_movie(Guid movieId)
+    {
+        var context = CreateTestContext();
+
+        var movie = new Movie
+        {
+            MovieId = movieId,
+            Title = "Original Movie",
+            YearOfRelease = 2023,
+            Genres = "Action",
+            UserId = "user-123",
+            DateUpdated = DateTime.UtcNow
+        };
+
+        context.Movies.Add(movie);
+        context.SaveChanges();
+
+        var handler = CreateHandler(context);
+        return (handler, context);
+    }
+
+    (UpdateMovieHandler handler, MoviesDbContext context) And_we_have_a_handler_without_movie()
+    {
+        var context = CreateTestContext();
+        var handler = CreateHandler(context);
+        return (handler, context);
+    }
+
+    async Task<bool> When_we_handle_the_command(
+        UpdateMovieHandler handler,
+        UpdateMovieCommand command)
+    {
+        return await handler.Handle(command, CancellationToken.None);
+    }
+
+    void Then_a_movie_should_be_updated(
+        bool result,
+        MoviesDbContext context,
+        UpdateMovieCommand command)
+    {
+        result.Should().BeTrue();
+
+        var updatedMovie = context.Movies.FirstOrDefault(m => m.MovieId == command.MovieId);
+        updatedMovie.Should().NotBeNull();
+        updatedMovie!.Title.Should().Be(command.Title);
+        updatedMovie.YearOfRelease.Should().Be(command.YearOfRelease);
+        updatedMovie.Genres.Should().Be(command.Genres);
+        updatedMovie.UserId.Should().Be(command.UserId);
+    }
+
+    void Then_the_result_should_be_true(bool result)
+    {
+        result.Should().BeTrue();
+    }
+
+    async Task Then_validation_exception_should_be_thrown(
+        UpdateMovieHandler handler,
+        UpdateMovieCommand command)
+    {
+        await Assert.ThrowsAsync<ValidationException>(
+            () => handler.Handle(command, CancellationToken.None));
+    }
+
+    // Helper methods to reduce duplication
+    private MoviesDbContext CreateTestContext()
+    {
+        var options = new DbContextOptionsBuilder<MoviesDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new MoviesDbContext(options);
+    }
+
+    private UpdateMovieHandler CreateHandler(MoviesDbContext context)
+    {
+        var validator = new UpdateMovieValidator(context);
+        var mockLogger = new Mock<ILogger<UpdateMovieHandler>>();
+        return new UpdateMovieHandler(context, validator, mockLogger.Object);
+    }
+}

--- a/Movies.Api.VerticalSlice.Api.Tests/Service/RatingsServiceTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Service/RatingsServiceTests.cs
@@ -1,0 +1,497 @@
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+using Movies.VerticalSlice.Api.Services;
+using Movies.VerticalSlice.Api.Shared.Constants;
+using Movies.VerticalSlice.Api.Shared.Dtos;
+using System.Net;
+using System.Text.Json;
+using Xunit;
+
+namespace Movies.Api.VerticalSlice.Api.Tests.Service;
+
+public class RatingsServiceTests
+{
+    #region GetAll Tests
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsUnauthorized_ThrowsException()
+    {
+        var service = And_we_have_a_service_that_returns_unauthorized();
+        await Then_unauthorized_exception_should_be_thrown_on_getall(service);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_CallsCorrectEndpoint()
+    {
+        var (service, requestCapture) = And_we_have_a_service_with_request_capture_and_json_response();
+        await When_we_get_all_ratings(service);
+        Then_correct_getall_endpoint_should_be_called(requestCapture);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsRatings_Successfully()
+    {
+        var expectedRatings = Given_we_have_a_list_of_ratings();
+        var service = And_we_have_a_service_that_returns_ratings(expectedRatings);
+        var ratings = await When_we_get_all_ratings(service);
+        Then_ratings_should_be_returned(ratings, expectedRatings);
+    }
+
+    #endregion
+
+    #region Create Tests
+
+    [Fact]
+    public async Task CreateAsync_WithValidRating_CallsCorrectEndpoint()
+    {
+        var ratingDto = Given_we_have_a_rating_dto();
+        var (service, requestCapture) = And_we_have_a_service_with_request_capture_created();
+        await When_we_create_the_rating(service, ratingDto);
+        Then_correct_create_endpoint_should_be_called(requestCapture);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsCreated_CompletesSuccessfully()
+    {
+        var ratingDto = Given_we_have_a_rating_dto();
+        var service = And_we_have_a_service_that_returns_created();
+        var response = await When_we_create_the_rating(service, ratingDto);
+        Then_response_should_be_created(response);
+    }
+
+    #endregion
+
+    #region Update Tests
+
+    [Fact]
+    public async Task UpdateAsync_WithValidRating_CallsCorrectEndpoint()
+    {
+        var ratingDto = Given_we_have_a_rating_dto();
+        var (service, requestCapture) = And_we_have_a_service_with_request_capture();
+        await When_we_update_the_rating(service, ratingDto);
+        Then_correct_update_endpoint_should_be_called(requestCapture, ratingDto.Id);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsNoContent_CompletesSuccessfully()
+    {
+        var ratingDto = Given_we_have_a_rating_dto();
+        var service = And_we_have_a_service_that_returns_no_content();
+        var response = await When_we_update_the_rating(service, ratingDto);
+        Then_response_should_be_no_content(response);
+    }
+
+    #endregion
+
+    #region Delete Tests
+
+    [Fact]
+    public async Task DeleteAsync_WithValidId_CallsCorrectEndpoint()
+    {
+        var ratingId = Given_we_have_a_rating_id();
+        var (service, requestCapture) = And_we_have_a_service_with_request_capture();
+        await When_we_delete_the_rating(service, ratingId);
+        Then_correct_delete_endpoint_should_be_called(requestCapture, ratingId);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ReturnsOK_CompletesSuccessfully()
+    {
+        var ratingId = Given_we_have_a_rating_id();
+        var service = And_we_have_a_service_that_returns_ok();
+        var response = await When_we_delete_the_rating(service, ratingId);
+        Then_response_should_be_successful(response);
+    }
+
+    #endregion
+
+    #region GetAllMovieNames Tests
+
+    [Fact]
+    public async Task GetAllMovieNamesAsync_WithoutTitle_CallsCorrectEndpoint()
+    {
+        var (service, requestCapture) = And_we_have_a_service_with_request_capture_and_movie_names_response();
+        await When_we_get_all_movie_names(service, "");
+        Then_correct_getall_movie_names_endpoint_should_be_called_without_title(requestCapture);
+    }
+
+    [Fact]
+    public async Task GetAllMovieNamesAsync_WithTitle_CallsCorrectEndpoint()
+    {
+        var title = "Test";
+        var (service, requestCapture) = And_we_have_a_service_with_request_capture_and_movie_names_response();
+        await When_we_get_all_movie_names(service, title);
+        Then_correct_getall_movie_names_endpoint_should_be_called_with_title(requestCapture, title);
+    }
+
+    [Fact]
+    public async Task GetAllMovieNamesAsync_ReturnsMovieNames_Successfully()
+    {
+        var expectedMovieNames = Given_we_have_a_list_of_movie_names();
+        var service = And_we_have_a_service_that_returns_movie_names(expectedMovieNames);
+        var movieNames = await When_we_get_all_movie_names(service, "");
+        Then_movie_names_should_be_returned(movieNames, expectedMovieNames);
+    }
+
+    #endregion
+
+    #region Given Methods
+
+    Guid Given_we_have_a_rating_id()
+    {
+        return Guid.NewGuid();
+    }
+
+    MovieRatingWithNameDto Given_we_have_a_rating_dto()
+    {
+        return new MovieRatingWithNameDto
+        {
+            Id = Guid.NewGuid(),
+            MovieId = Guid.NewGuid(),
+            MovieName = "Test Movie",
+            Rating = 4.5f,
+            DateUpdated = DateTime.UtcNow
+        };
+    }
+
+    List<MovieRatingWithNameDto> Given_we_have_a_list_of_ratings()
+    {
+        return new List<MovieRatingWithNameDto>
+        {
+            new MovieRatingWithNameDto { Id = Guid.NewGuid(), MovieId = Guid.NewGuid(), MovieName = "Movie 1", Rating = 4.5f, DateUpdated = DateTime.UtcNow },
+            new MovieRatingWithNameDto { Id = Guid.NewGuid(), MovieId = Guid.NewGuid(), MovieName = "Movie 2", Rating = 3.5f, DateUpdated = DateTime.UtcNow }
+        };
+    }
+
+    List<MovieNameDto> Given_we_have_a_list_of_movie_names()
+    {
+        return new List<MovieNameDto>
+        {
+            new MovieNameDto { MovieId = Guid.NewGuid(), MovieName = "Movie 1" },
+            new MovieNameDto { MovieId = Guid.NewGuid(), MovieName = "Movie 2" }
+        };
+    }
+
+    #endregion
+
+    #region And Methods
+
+    RatingsService And_we_have_a_service_that_returns_unauthorized()
+    {
+        var handler = CreateMockHttpHandler(HttpStatusCode.Unauthorized);
+        return CreateRatingsService(handler);
+    }
+
+    (RatingsService service, RequestCapture requestCapture) And_we_have_a_service_with_request_capture()
+    {
+        var requestCapture = new RequestCapture();
+        
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => requestCapture.CapturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var service = CreateRatingsService(handler);
+        
+        return (service, requestCapture);
+    }
+
+    (RatingsService service, RequestCapture requestCapture) And_we_have_a_service_with_request_capture_created()
+    {
+        var requestCapture = new RequestCapture();
+        
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => requestCapture.CapturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created));
+
+        var service = CreateRatingsService(handler);
+        
+        return (service, requestCapture);
+    }
+
+    (RatingsService service, RequestCapture requestCapture) And_we_have_a_service_with_request_capture_and_json_response()
+    {
+        var requestCapture = new RequestCapture();
+        var ratings = Given_we_have_a_list_of_ratings();
+        var json = JsonSerializer.Serialize(ratings);
+        
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => requestCapture.CapturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            });
+
+        var service = CreateRatingsService(handler);
+        
+        return (service, requestCapture);
+    }
+
+    (RatingsService service, RequestCapture requestCapture) And_we_have_a_service_with_request_capture_and_movie_names_response()
+    {
+        var requestCapture = new RequestCapture();
+        var movieNames = Given_we_have_a_list_of_movie_names();
+        var json = JsonSerializer.Serialize(movieNames);
+        
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => requestCapture.CapturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            });
+
+        var service = CreateRatingsService(handler);
+        
+        return (service, requestCapture);
+    }
+
+    RatingsService And_we_have_a_service_that_returns_ok()
+    {
+        var handler = CreateMockHttpHandler(HttpStatusCode.OK);
+        return CreateRatingsService(handler);
+    }
+
+    RatingsService And_we_have_a_service_that_returns_no_content()
+    {
+        var handler = CreateMockHttpHandler(HttpStatusCode.NoContent);
+        return CreateRatingsService(handler);
+    }
+
+    RatingsService And_we_have_a_service_that_returns_created()
+    {
+        var handler = CreateMockHttpHandler(HttpStatusCode.Created);
+        return CreateRatingsService(handler);
+    }
+
+    RatingsService And_we_have_a_service_that_returns_ratings(List<MovieRatingWithNameDto> ratings)
+    {
+        var json = JsonSerializer.Serialize(ratings);
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            });
+        
+        return CreateRatingsService(handler);
+    }
+
+    RatingsService And_we_have_a_service_that_returns_movie_names(List<MovieNameDto> movieNames)
+    {
+        var json = JsonSerializer.Serialize(movieNames);
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            });
+        
+        return CreateRatingsService(handler);
+    }
+
+    #endregion
+
+    #region When Methods
+
+    async Task<List<MovieRatingWithNameDto>?> When_we_get_all_ratings(RatingsService service)
+    {
+        return await service.GetAllAsync();
+    }
+
+    async Task<HttpResponseMessage> When_we_create_the_rating(
+        RatingsService service,
+        MovieRatingWithNameDto ratingDto)
+    {
+        return await service.CreateAsync(ratingDto);
+    }
+
+    async Task<HttpResponseMessage> When_we_update_the_rating(
+        RatingsService service,
+        MovieRatingWithNameDto ratingDto)
+    {
+        return await service.UpdateAsync(ratingDto);
+    }
+
+    async Task<HttpResponseMessage> When_we_delete_the_rating(
+        RatingsService service,
+        Guid ratingId)
+    {
+        return await service.DeleteAsync(ratingId);
+    }
+
+    async Task<List<MovieNameDto>?> When_we_get_all_movie_names(
+        RatingsService service,
+        string title)
+    {
+        return await service.GetAllMovieNamesAsync(title);
+    }
+
+    #endregion
+
+    #region Then Methods
+
+    async Task Then_unauthorized_exception_should_be_thrown_on_getall(RatingsService service)
+    {
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => service.GetAllAsync());
+    }
+
+    void Then_correct_getall_endpoint_should_be_called(RequestCapture requestCapture)
+    {
+        requestCapture.CapturedRequest.Should().NotBeNull();
+        requestCapture.CapturedRequest!.Method.Should().Be(HttpMethod.Get);
+        requestCapture.CapturedRequest.RequestUri!.AbsolutePath.Should().Be(ApiEndpoints.Ratings.GetAll);
+    }
+
+    void Then_correct_create_endpoint_should_be_called(RequestCapture requestCapture)
+    {
+        requestCapture.CapturedRequest.Should().NotBeNull();
+        requestCapture.CapturedRequest!.Method.Should().Be(HttpMethod.Post);
+        requestCapture.CapturedRequest.RequestUri!.AbsolutePath.Should().Be(ApiEndpoints.Ratings.Base);
+    }
+
+    void Then_correct_update_endpoint_should_be_called(
+        RequestCapture requestCapture,
+        Guid ratingId)
+    {
+        requestCapture.CapturedRequest.Should().NotBeNull();
+        requestCapture.CapturedRequest!.Method.Should().Be(HttpMethod.Put);
+        requestCapture.CapturedRequest.RequestUri!.AbsolutePath.Should().Be($"{ApiEndpoints.Ratings.Base}/{ratingId}");
+    }
+
+    void Then_correct_delete_endpoint_should_be_called(
+        RequestCapture requestCapture,
+        Guid ratingId)
+    {
+        requestCapture.CapturedRequest.Should().NotBeNull();
+        requestCapture.CapturedRequest!.Method.Should().Be(HttpMethod.Delete);
+        requestCapture.CapturedRequest.RequestUri!.AbsolutePath.Should().Be($"{ApiEndpoints.Ratings.Base}/{ratingId}");
+    }
+
+    void Then_correct_getall_movie_names_endpoint_should_be_called_without_title(RequestCapture requestCapture)
+    {
+        requestCapture.CapturedRequest.Should().NotBeNull();
+        requestCapture.CapturedRequest!.Method.Should().Be(HttpMethod.Get);
+        requestCapture.CapturedRequest.RequestUri!.AbsolutePath.Should().Be($"{ApiEndpoints.Movies.Names}/");
+    }
+
+    void Then_correct_getall_movie_names_endpoint_should_be_called_with_title(
+        RequestCapture requestCapture,
+        string title)
+    {
+        requestCapture.CapturedRequest.Should().NotBeNull();
+        requestCapture.CapturedRequest!.Method.Should().Be(HttpMethod.Get);
+        requestCapture.CapturedRequest.RequestUri!.AbsolutePath.Should().Be(ApiEndpoints.Movies.Names);
+        requestCapture.CapturedRequest.RequestUri!.Query.Should().Contain($"title={Uri.EscapeDataString(title)}");
+    }
+
+    void Then_response_should_be_successful(HttpResponseMessage response)
+    {
+        response.Should().NotBeNull();
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    void Then_response_should_be_no_content(HttpResponseMessage response)
+    {
+        response.Should().NotBeNull();
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    void Then_response_should_be_created(HttpResponseMessage response)
+    {
+        response.Should().NotBeNull();
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    void Then_ratings_should_be_returned(
+        List<MovieRatingWithNameDto>? ratings,
+        List<MovieRatingWithNameDto> expectedRatings)
+    {
+        ratings.Should().NotBeNull();
+        ratings.Should().HaveCount(expectedRatings.Count);
+        ratings![0].MovieName.Should().Be(expectedRatings[0].MovieName);
+        ratings[1].MovieName.Should().Be(expectedRatings[1].MovieName);
+    }
+
+    void Then_movie_names_should_be_returned(
+        List<MovieNameDto>? movieNames,
+        List<MovieNameDto> expectedMovieNames)
+    {
+        movieNames.Should().NotBeNull();
+        movieNames.Should().HaveCount(expectedMovieNames.Count);
+        movieNames![0].MovieName.Should().Be(expectedMovieNames[0].MovieName);
+        movieNames[1].MovieName.Should().Be(expectedMovieNames[1].MovieName);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private Mock<HttpMessageHandler> CreateMockHttpHandler(HttpStatusCode statusCode)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(statusCode));
+        
+        return handler;
+    }
+
+    private RatingsService CreateRatingsService(Mock<HttpMessageHandler> handler)
+    {
+        var httpClient = new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+        
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient("AuthorizedClient")).Returns(httpClient);
+
+        return new RatingsService(factory.Object);
+    }
+
+    private class RequestCapture
+    {
+        public HttpRequestMessage? CapturedRequest { get; set; }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Introduced comprehensive xUnit test classes for CreateMovieHandler, UpdateMovieHandler, DeleteMovieHandler, and RatingsService. Tests cover successful operations, validation failures, and error scenarios using in-memory EF Core, FluentAssertions, and Moq. These tests improve coverage and reliability of core Movies API features.