### PR TITLE
Add comprehensive unit tests for Movies and Ratings endpoints

### DIFF
--- a/Movies.Api.VerticalSlice.Api.Tests/Features/Movies/GetAllMoviesEndpointTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Features/Movies/GetAllMoviesEndpointTests.cs
@@ -1,0 +1,334 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Movies.VerticalSlice.Api.Data.Database;
+using Movies.VerticalSlice.Api.Data.Models;
+using Movies.VerticalSlice.Api.Shared.Dtos;
+using Xunit;
+
+namespace Movies.Api.VerticalSlice.Api.Tests.Features.Movies;
+
+public class GetAllMoviesEndpointTests : IDisposable
+{
+    private readonly MoviesDbContext _context;
+
+    public GetAllMoviesEndpointTests()
+    {
+        var options = new DbContextOptionsBuilder<MoviesDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new MoviesDbContext(options);
+        SeedTestData();
+    }
+
+    #region Filter Tests
+
+    [Fact]
+    public async Task GetMovies_FilterByTitle_ReturnsOnlyMatchingMovies()
+    {
+        Given_we_have_seeded_test_data();
+        var title = And_we_have_title_filter();
+        var movies = await When_we_filter_movies_by_title(title);
+        Then_movies_should_have_count(movies, 2);
+        And_all_movies_should_contain_title(movies, title);
+    }
+
+    [Fact]
+    public async Task GetMovies_FilterByYearOfRelease_ReturnsOnlyMatchingMovies()
+    {
+        Given_we_have_seeded_test_data();
+        var year = And_we_have_year_filter();
+        var movies = await When_we_filter_movies_by_year(year);
+        Then_movies_should_have_count(movies, 2);
+        And_all_movies_should_have_year(movies, year);
+    }
+
+    [Fact]
+    public async Task GetMovies_CombinedFilters_ReturnsCorrectSubset()
+    {
+        Given_we_have_seeded_test_data();
+        var (title, year) = And_we_have_combined_filters();
+        var movies = await When_we_filter_movies_by_title_and_year(title, year);
+        Then_movies_should_have_count(movies, 2);
+        And_all_movies_should_match_filters(movies, title, year);
+    }
+
+    #endregion
+
+    #region Sort Tests
+
+    [Fact]
+    public async Task GetMovies_SortByTitleAscending_ReturnsSortedMovies()
+    {
+        Given_we_have_seeded_test_data();
+        var (sortField, sortOrder) = And_we_have_title_ascending_sort();
+        var movies = await When_we_get_movies_with_sorting(sortField, sortOrder);
+        Then_movies_should_be_sorted_by_title_ascending(movies);
+    }
+
+    [Fact]
+    public async Task GetMovies_SortByTitleDescending_ReturnsSortedMovies()
+    {
+        Given_we_have_seeded_test_data();
+        var (sortField, sortOrder) = And_we_have_title_descending_sort();
+        var movies = await When_we_get_movies_with_sorting(sortField, sortOrder);
+        Then_movies_should_be_sorted_by_title_descending(movies);
+    }
+
+    [Fact]
+    public async Task GetMovies_SortByYearAscending_ReturnsSortedMovies()
+    {
+        Given_we_have_seeded_test_data();
+        var (sortField, sortOrder) = And_we_have_year_ascending_sort();
+        var movies = await When_we_get_movies_with_sorting(sortField, sortOrder);
+        Then_movies_should_be_sorted_by_year_ascending(movies);
+    }
+
+    [Fact]
+    public async Task GetMovies_SortByYearDescending_ReturnsSortedMovies()
+    {
+        Given_we_have_seeded_test_data();
+        var (sortField, sortOrder) = And_we_have_year_descending_sort();
+        var movies = await When_we_get_movies_with_sorting(sortField, sortOrder);
+        Then_movies_should_be_sorted_by_year_descending(movies);
+    }
+
+    #endregion
+
+    #region Limit Tests
+
+    [Fact]
+    public async Task GetMovies_WithLimit_ReturnsLimitedResults()
+    {
+        Given_we_have_seeded_test_data();
+        var limit = And_we_have_limit(3);
+        var movies = await When_we_get_movies_with_limit(limit);
+        Then_movies_should_have_count(movies, 3);
+    }
+
+    [Fact]
+    public async Task GetMovies_NoLimit_ReturnsAllMovies()
+    {
+        Given_we_have_seeded_test_data();
+        var movies = await When_we_get_all_movies();
+        Then_movies_should_have_count(movies, 5);
+    }
+
+    #endregion
+
+    #region Given Methods
+
+    void Given_we_have_seeded_test_data()
+    {
+        // Data already seeded in constructor
+    }
+
+    #endregion
+
+    #region And Methods
+
+    string And_we_have_title_filter()
+    {
+        return "Test Movie";
+    }
+
+    int And_we_have_year_filter()
+    {
+        return 2020;
+    }
+
+    (string title, int year) And_we_have_combined_filters()
+    {
+        return ("Test Movie", 2020);
+    }
+
+    (string sortField, SortOrder sortOrder) And_we_have_title_ascending_sort()
+    {
+        return ("title", SortOrder.Ascending);
+    }
+
+    (string sortField, SortOrder sortOrder) And_we_have_title_descending_sort()
+    {
+        return ("title", SortOrder.Descending);
+    }
+
+    (string sortField, SortOrder sortOrder) And_we_have_year_ascending_sort()
+    {
+        return ("yearofrelease", SortOrder.Ascending);
+    }
+
+    (string sortField, SortOrder sortOrder) And_we_have_year_descending_sort()
+    {
+        return ("yearofrelease", SortOrder.Descending);
+    }
+
+    int And_we_have_limit(int limit)
+    {
+        return limit;
+    }
+
+    void And_all_movies_should_contain_title(List<Movie> movies, string title)
+    {
+        movies.Should().AllSatisfy(m => m.Title.Should().Contain(title));
+    }
+
+    void And_all_movies_should_have_year(List<Movie> movies, int year)
+    {
+        movies.Should().AllSatisfy(m => m.YearOfRelease.Should().Be(year));
+    }
+
+    void And_all_movies_should_match_filters(List<Movie> movies, string title, int year)
+    {
+        movies.Should().AllSatisfy(m =>
+        {
+            m.Title.Should().Contain(title);
+            m.YearOfRelease.Should().Be(year);
+        });
+    }
+
+    #endregion
+
+    #region When Methods
+
+    async Task<List<Movie>> When_we_filter_movies_by_title(string title)
+    {
+        return await _context.Movies
+            .Where(m => m.Title.Contains(title))
+            .ToListAsync();
+    }
+
+    async Task<List<Movie>> When_we_filter_movies_by_year(int year)
+    {
+        return await _context.Movies
+            .Where(m => m.YearOfRelease == year)
+            .ToListAsync();
+    }
+
+    async Task<List<Movie>> When_we_filter_movies_by_title_and_year(string title, int year)
+    {
+        return await _context.Movies
+            .Where(m => m.Title.Contains(title) && m.YearOfRelease == year)
+            .ToListAsync();
+    }
+
+    async Task<List<Movie>> When_we_get_movies_with_sorting(string sortField, SortOrder sortOrder)
+    {
+        var query = _context.Movies.AsQueryable();
+
+        query = sortField.ToLowerInvariant() switch
+        {
+            "title" => sortOrder == SortOrder.Ascending
+                ? query.OrderBy(m => m.Title)
+                : query.OrderByDescending(m => m.Title),
+            "yearofrelease" => sortOrder == SortOrder.Ascending
+                ? query.OrderBy(m => m.YearOfRelease)
+                : query.OrderByDescending(m => m.YearOfRelease),
+            _ => query.OrderBy(m => m.Title)
+        };
+
+        return await query.ToListAsync();
+    }
+
+    async Task<List<Movie>> When_we_get_movies_with_limit(int limit)
+    {
+        return await _context.Movies
+            .OrderBy(m => m.Title)
+            .Take(limit)
+            .ToListAsync();
+    }
+
+    async Task<List<Movie>> When_we_get_all_movies()
+    {
+        return await _context.Movies.ToListAsync();
+    }
+
+    #endregion
+
+    #region Then Methods
+
+    void Then_movies_should_have_count(List<Movie> movies, int expectedCount)
+    {
+        movies.Should().HaveCount(expectedCount);
+    }
+
+    void Then_movies_should_be_sorted_by_title_ascending(List<Movie> movies)
+    {
+        movies.Should().BeInAscendingOrder(m => m.Title);
+    }
+
+    void Then_movies_should_be_sorted_by_title_descending(List<Movie> movies)
+    {
+        movies.Should().BeInDescendingOrder(m => m.Title);
+    }
+
+    void Then_movies_should_be_sorted_by_year_ascending(List<Movie> movies)
+    {
+        movies.Should().BeInAscendingOrder(m => m.YearOfRelease);
+    }
+
+    void Then_movies_should_be_sorted_by_year_descending(List<Movie> movies)
+    {
+        movies.Should().BeInDescendingOrder(m => m.YearOfRelease);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private void SeedTestData()
+    {
+        var movies = new List<Movie>
+        {
+            new Movie
+            {
+                MovieId = Guid.NewGuid(),
+                Title = "Test Movie 1",
+                YearOfRelease = 2020,
+                Genres = "Action,Drama",
+                UserId = "user1"
+            },
+            new Movie
+            {
+                MovieId = Guid.NewGuid(),
+                Title = "Another Movie 2",
+                YearOfRelease = 2021,
+                Genres = "Comedy",
+                UserId = "user1"
+            },
+            new Movie
+            {
+                MovieId = Guid.NewGuid(),
+                Title = "Test Movie 3",
+                YearOfRelease = 2020,
+                Genres = "Thriller",
+                UserId = "user2"
+            },
+            new Movie
+            {
+                MovieId = Guid.NewGuid(),
+                Title = "Different Film 4",
+                YearOfRelease = 2019,
+                Genres = "Horror",
+                UserId = "user2"
+            },
+            new Movie
+            {
+                MovieId = Guid.NewGuid(),
+                Title = "Classic Film 5",
+                YearOfRelease = 2018,
+                Genres = "Drama",
+                UserId = "user3"
+            }
+        };
+
+        _context.Movies.AddRange(movies);
+        _context.SaveChanges();
+    }
+
+    #endregion
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+}

--- a/Movies.Api.VerticalSlice.Api.Tests/Features/Ratings/GetAllRatingsEndpointTests.cs
+++ b/Movies.Api.VerticalSlice.Api.Tests/Features/Ratings/GetAllRatingsEndpointTests.cs
@@ -1,0 +1,453 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Movies.VerticalSlice.Api.Data.Database;
+using Movies.VerticalSlice.Api.Data.Models;
+using Xunit;
+
+namespace Movies.Api.VerticalSlice.Api.Tests.Features.Ratings;
+
+public class GetAllRatingsEndpointTests : IDisposable
+{
+    private readonly MoviesDbContext _context;
+    private readonly Guid _movie1Id = Guid.NewGuid();
+    private readonly Guid _movie2Id = Guid.NewGuid();
+    private readonly Guid _movie3Id = Guid.NewGuid();
+
+    public GetAllRatingsEndpointTests()
+    {
+        var options = new DbContextOptionsBuilder<MoviesDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new MoviesDbContext(options);
+        SeedTestData();
+    }
+
+    #region Basic Retrieval Tests
+
+    [Fact]
+    public async Task GetRatings_WithSeededData_ReturnsAllRatings()
+    {
+        Given_we_have_seeded_test_data();
+        var ratings = await When_we_get_all_ratings();
+        Then_ratings_should_have_count(ratings, 5);
+    }
+
+    [Fact]
+    public async Task GetRatings_WithJoinedData_IncludesMovieAndUserInformation()
+    {
+        Given_we_have_seeded_test_data();
+        var ratings = await When_we_get_ratings_with_movie_and_user_info();
+        Then_all_ratings_should_have_movie_name(ratings);
+        And_all_ratings_should_have_user_name(ratings);
+    }
+
+    #endregion
+
+    #region Filter Tests
+
+    [Fact]
+    public async Task GetRatings_FilterByMovieId_ReturnsOnlyMatchingRatings()
+    {
+        Given_we_have_seeded_test_data();
+        var movieId = And_we_have_first_movie_id();
+        var ratings = await When_we_filter_ratings_by_movie_id(movieId);
+        Then_ratings_should_have_count(ratings, 2);
+        And_all_ratings_should_have_movie_id(ratings, movieId);
+    }
+
+    [Fact]
+    public async Task GetRatings_FilterByUserId_ReturnsOnlyMatchingRatings()
+    {
+        Given_we_have_seeded_test_data();
+        var userId = And_we_have_first_user_id();
+        var ratings = await When_we_filter_ratings_by_user_id(userId);
+        Then_ratings_should_have_count(ratings, 2);
+        And_all_ratings_should_have_user_id(ratings, userId);
+    }
+
+    [Fact]
+    public async Task GetRatings_FilterByRatingValue_ReturnsOnlyMatchingRatings()
+    {
+        Given_we_have_seeded_test_data();
+        var ratingValue = And_we_have_rating_value_filter();
+        var ratings = await When_we_filter_ratings_by_value(ratingValue);
+        Then_ratings_should_have_count(ratings, 1);
+        And_all_ratings_should_have_value(ratings, ratingValue);
+    }
+
+    #endregion
+
+    #region Sort Tests
+
+    [Fact]
+    public async Task GetRatings_SortByMovieName_ReturnsSortedRatings()
+    {
+        Given_we_have_seeded_test_data();
+        var ratings = await When_we_get_ratings_sorted_by_movie_name();
+        Then_ratings_should_be_sorted_by_movie_name(ratings);
+    }
+
+    [Fact]
+    public async Task GetRatings_SortByRatingDescending_ReturnsSortedRatings()
+    {
+        Given_we_have_seeded_test_data();
+        var ratings = await When_we_get_ratings_sorted_by_value_descending();
+        Then_ratings_should_be_sorted_by_value_descending(ratings);
+    }
+
+    [Fact]
+    public async Task GetRatings_SortByDateUpdated_ReturnsSortedRatings()
+    {
+        Given_we_have_seeded_test_data();
+        var ratings = await When_we_get_ratings_sorted_by_date_updated();
+        Then_ratings_should_be_sorted_by_date_updated(ratings);
+    }
+
+    #endregion
+
+    #region Aggregation Tests
+
+    [Fact]
+    public async Task GetRatings_AverageRatingPerMovie_CalculatesCorrectly()
+    {
+        Given_we_have_seeded_test_data();
+        var movieId = And_we_have_first_movie_id();
+        var averageRating = await When_we_calculate_average_rating_for_movie(movieId);
+        Then_average_rating_should_be(averageRating, 4.0f);
+    }
+
+    [Fact]
+    public async Task GetRatings_CountRatingsPerMovie_CountsCorrectly()
+    {
+        Given_we_have_seeded_test_data();
+        var movieId = And_we_have_first_movie_id();
+        var count = await When_we_count_ratings_for_movie(movieId);
+        Then_rating_count_should_be(count, 2);
+    }
+
+    #endregion
+
+    #region Given Methods
+
+    void Given_we_have_seeded_test_data()
+    {
+        // Data already seeded in constructor
+    }
+
+    #endregion
+
+    #region And Methods
+
+    Guid And_we_have_first_movie_id()
+    {
+        return _movie1Id;
+    }
+
+    string And_we_have_first_user_id()
+    {
+        return "user1";
+    }
+
+    float And_we_have_rating_value_filter()
+    {
+        return 5.0f;
+    }
+
+    void And_all_ratings_should_have_movie_id(List<MovieRating> ratings, Guid movieId)
+    {
+        ratings.Should().AllSatisfy(r => r.MovieId.Should().Be(movieId));
+    }
+
+    void And_all_ratings_should_have_user_id(List<MovieRating> ratings, string userId)
+    {
+        ratings.Should().AllSatisfy(r => r.UserId.Should().Be(userId));
+    }
+
+    void And_all_ratings_should_have_value(List<MovieRating> ratings, float value)
+    {
+        ratings.Should().AllSatisfy(r => r.Rating.Should().Be(value));
+    }
+
+    void And_all_ratings_should_have_movie_name(List<RatingWithMovieAndUser> ratings)
+    {
+        ratings.Should().AllSatisfy(r => r.MovieName.Should().NotBeNullOrEmpty());
+    }
+
+    void And_all_ratings_should_have_user_name(List<RatingWithMovieAndUser> ratings)
+    {
+        ratings.Should().AllSatisfy(r => r.UserName.Should().NotBeNullOrEmpty());
+    }
+
+    #endregion
+
+    #region When Methods
+
+    async Task<List<MovieRating>> When_we_get_all_ratings()
+    {
+        return await _context.Ratings.ToListAsync();
+    }
+
+    async Task<List<RatingWithMovieAndUser>> When_we_get_ratings_with_movie_and_user_info()
+    {
+        return await _context.Ratings
+            .Join(_context.Movies,
+                rating => rating.MovieId,
+                movie => movie.MovieId,
+                (rating, movie) => new { Rating = rating, Movie = movie })
+            .Join(_context.Users,
+                rm => rm.Rating.UserId,
+                user => user.Id,
+                (rm, user) => new RatingWithMovieAndUser
+                {
+                    Id = rm.Rating.Id,
+                    MovieId = rm.Rating.MovieId,
+                    Rating = rm.Rating.Rating,
+                    UserId = rm.Rating.UserId,
+                    DateUpdated = rm.Rating.DateUpdated,
+                    MovieName = rm.Movie.Title,
+                    UserName = user.UserName!
+                })
+            .ToListAsync();
+    }
+
+    async Task<List<MovieRating>> When_we_filter_ratings_by_movie_id(Guid movieId)
+    {
+        return await _context.Ratings
+            .Where(r => r.MovieId == movieId)
+            .ToListAsync();
+    }
+
+    async Task<List<MovieRating>> When_we_filter_ratings_by_user_id(string userId)
+    {
+        return await _context.Ratings
+            .Where(r => r.UserId == userId)
+            .ToListAsync();
+    }
+
+    async Task<List<MovieRating>> When_we_filter_ratings_by_value(float ratingValue)
+    {
+        return await _context.Ratings
+            .Where(r => r.Rating == ratingValue)
+            .ToListAsync();
+    }
+
+    async Task<List<RatingWithMovieAndUser>> When_we_get_ratings_sorted_by_movie_name()
+    {
+        return await _context.Ratings
+            .Join(_context.Movies,
+                rating => rating.MovieId,
+                movie => movie.MovieId,
+                (rating, movie) => new { Rating = rating, Movie = movie })
+            .Join(_context.Users,
+                rm => rm.Rating.UserId,
+                user => user.Id,
+                (rm, user) => new RatingWithMovieAndUser
+                {
+                    Id = rm.Rating.Id,
+                    MovieId = rm.Rating.MovieId,
+                    Rating = rm.Rating.Rating,
+                    UserId = rm.Rating.UserId,
+                    DateUpdated = rm.Rating.DateUpdated,
+                    MovieName = rm.Movie.Title,
+                    UserName = user.UserName!
+                })
+            .OrderBy(r => r.MovieName)
+            .ToListAsync();
+    }
+
+    async Task<List<MovieRating>> When_we_get_ratings_sorted_by_value_descending()
+    {
+        return await _context.Ratings
+            .OrderByDescending(r => r.Rating)
+            .ToListAsync();
+    }
+
+    async Task<List<MovieRating>> When_we_get_ratings_sorted_by_date_updated()
+    {
+        return await _context.Ratings
+            .OrderBy(r => r.DateUpdated)
+            .ToListAsync();
+    }
+
+    async Task<float> When_we_calculate_average_rating_for_movie(Guid movieId)
+    {
+        return await _context.Ratings
+            .Where(r => r.MovieId == movieId)
+            .AverageAsync(r => r.Rating);
+    }
+
+    async Task<int> When_we_count_ratings_for_movie(Guid movieId)
+    {
+        return await _context.Ratings
+            .Where(r => r.MovieId == movieId)
+            .CountAsync();
+    }
+
+    #endregion
+
+    #region Then Methods
+
+    void Then_ratings_should_have_count(List<MovieRating> ratings, int expectedCount)
+    {
+        ratings.Should().HaveCount(expectedCount);
+    }
+
+    void Then_ratings_should_be_sorted_by_movie_name(List<RatingWithMovieAndUser> ratings)
+    {
+        ratings.Should().BeInAscendingOrder(r => r.MovieName);
+    }
+
+    void Then_ratings_should_be_sorted_by_value_descending(List<MovieRating> ratings)
+    {
+        ratings.Should().BeInDescendingOrder(r => r.Rating);
+    }
+
+    void Then_ratings_should_be_sorted_by_date_updated(List<MovieRating> ratings)
+    {
+        ratings.Should().BeInAscendingOrder(r => r.DateUpdated);
+    }
+
+    void Then_average_rating_should_be(float actualRating, float expectedRating)
+    {
+        actualRating.Should().BeApproximately(expectedRating, 0.01f);
+    }
+
+    void Then_rating_count_should_be(int actualCount, int expectedCount)
+    {
+        actualCount.Should().Be(expectedCount);
+    }
+
+    void Then_all_ratings_should_have_movie_name(List<RatingWithMovieAndUser> ratings)
+    {
+        ratings.Should().AllSatisfy(r => r.MovieName.Should().NotBeNullOrEmpty());
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private void SeedTestData()
+    {
+        var users = new List<ApplicationUser>
+        {
+            new ApplicationUser
+            {
+                Id = "user1",
+                UserName = "testuser1",
+                Email = "test1@example.com",
+                EmailConfirmed = true
+            },
+            new ApplicationUser
+            {
+                Id = "user2",
+                UserName = "testuser2",
+                Email = "test2@example.com",
+                EmailConfirmed = true
+            },
+            new ApplicationUser
+            {
+                Id = "user3",
+                UserName = "testuser3",
+                Email = "test3@example.com",
+                EmailConfirmed = true
+            }
+        };
+
+        var movies = new List<Movie>
+        {
+            new Movie
+            {
+                MovieId = _movie1Id,
+                Title = "Test Movie 1",
+                YearOfRelease = 2020,
+                Genres = "Action,Drama",
+                UserId = "user1"
+            },
+            new Movie
+            {
+                MovieId = _movie2Id,
+                Title = "Another Movie 2",
+                YearOfRelease = 2021,
+                Genres = "Comedy",
+                UserId = "user2"
+            },
+            new Movie
+            {
+                MovieId = _movie3Id,
+                Title = "Third Movie 3",
+                YearOfRelease = 2019,
+                Genres = "Thriller",
+                UserId = "user3"
+            }
+        };
+
+        var ratings = new List<MovieRating>
+        {
+            new MovieRating
+            {
+                Id = Guid.NewGuid(),
+                MovieId = _movie1Id,
+                Rating = 4.5f,
+                UserId = "user1",
+                DateUpdated = DateTime.UtcNow.AddDays(-5)
+            },
+            new MovieRating
+            {
+                Id = Guid.NewGuid(),
+                MovieId = _movie1Id,
+                Rating = 3.5f,
+                UserId = "user2",
+                DateUpdated = DateTime.UtcNow.AddDays(-4)
+            },
+            new MovieRating
+            {
+                Id = Guid.NewGuid(),
+                MovieId = _movie2Id,
+                Rating = 5.0f,
+                UserId = "user1",
+                DateUpdated = DateTime.UtcNow.AddDays(-3)
+            },
+            new MovieRating
+            {
+                Id = Guid.NewGuid(),
+                MovieId = _movie2Id,
+                Rating = 4.0f,
+                UserId = "user3",
+                DateUpdated = DateTime.UtcNow.AddDays(-2)
+            },
+            new MovieRating
+            {
+                Id = Guid.NewGuid(),
+                MovieId = _movie3Id,
+                Rating = 3.0f,
+                UserId = "user2",
+                DateUpdated = DateTime.UtcNow.AddDays(-1)
+            }
+        };
+
+        _context.Users.AddRange(users);
+        _context.Movies.AddRange(movies);
+        _context.Ratings.AddRange(ratings);
+        _context.SaveChanges();
+    }
+
+    #endregion
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private class RatingWithMovieAndUser
+    {
+        public Guid Id { get; set; }
+        public Guid MovieId { get; set; }
+        public float Rating { get; set; }
+        public string UserId { get; set; } = string.Empty;
+        public DateTime? DateUpdated { get; set; }
+        public string MovieName { get; set; } = string.Empty;
+        public string UserName { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
Added GetAllMoviesEndpointTests and GetAllRatingsEndpointTests using in-memory database. Tests cover filtering, sorting, limiting, and aggregation scenarios for both endpoints. Seed data and helper methods included; FluentAssertions used for expressive assertions.